### PR TITLE
Export Wonka.bs.js for ReasonML support

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
       "types": "./dist/types/src/Wonka.d.ts",
       "source": "./src/Wonka.ts"
     },
+    "./src/Wonka.bs.js": "./src/Wonka.bs.js",
     "./package.json": "./package.json",
     "./": "./"
   },


### PR DESCRIPTION
Newer versions of Node.js, starting at least with `12.19` throw an error about "./src/Wonka.bs.js" not being exported by the package when using Wonka from Reason. This change exports the compiled BS artifact and silences that error.

Resolves #97 