### PR TITLE
chore: Derive common Wonka sources from make source

### DIFF
--- a/src/__tests__/sources.test.ts
+++ b/src/__tests__/sources.test.ts
@@ -275,6 +275,7 @@ describe('fromPromise', () => {
     expect(signals).toEqual([start(expect.any(Function))]);
 
     await promise;
+    await Promise.resolve();
 
     expect(signals).toEqual([start(expect.any(Function)), push(1), SignalKind.End]);
   });

--- a/src/sources.ts
+++ b/src/sources.ts
@@ -1,5 +1,6 @@
 import { Source, Sink, SignalKind, TalkbackKind, Observer, Subject, TeardownFn } from './types';
-import { push, start, talkbackPlaceholder } from './helpers';
+import { push, start, talkbackPlaceholder, teardownPlaceholder } from './helpers';
+import { share } from './operators';
 
 export function fromArray<T>(array: T[]): Source<T> {
   return sink => {
@@ -73,31 +74,21 @@ export function make<T>(produce: (observer: Observer<T>) => TeardownFn): Source<
 }
 
 export function makeSubject<T>(): Subject<T> {
-  let sinks: Sink<T>[] = [];
-  let ended = false;
+  let next: Subject<T>['next'] | void;
+  let complete: Subject<T>['complete'] | void;
   return {
-    source(sink: Sink<T>) {
-      sinks.push(sink);
-      sink(
-        start(signal => {
-          if (signal === TalkbackKind.Close) {
-            const index = sinks.indexOf(sink);
-            if (index > -1) (sinks = sinks.slice()).splice(index, 1);
-          }
-        })
-      );
-    },
+    source: share(
+      make(observer => {
+        next = observer.next;
+        complete = observer.complete;
+        return teardownPlaceholder;
+      })
+    ),
     next(value: T) {
-      if (!ended) {
-        const signal = push(value);
-        for (let i = 0, a = sinks, l = sinks.length; i < l; i++) a[i](signal);
-      }
+      if (next) next(value);
     },
     complete() {
-      if (!ended) {
-        ended = true;
-        for (let i = 0, a = sinks, l = sinks.length; i < l; i++) a[i](SignalKind.End);
-      }
+      if (complete) complete();
     },
   };
 }


### PR DESCRIPTION
This basically just cleans up the implementation of some common sources to be derived from `make`. This is basically to save on some bytes in the resulting bundle, delete duplicate functionality, and to recombine some old sources into less maintainable code.

- `makeSubject` has been replaced with `make` + `share`
- `interval` is `make`-based now
- `fromDomEvent` is `make`-based now
- `fromPromise` is `make`-based now and its timing has been fixed (delayed using `Promise.resolve`)