### PR TITLE
feat: Implement fromIterable and replace fromArray

### DIFF
--- a/perf/package.json
+++ b/perf/package.json
@@ -11,6 +11,7 @@
     "benchr": "^4.3.0"
   },
   "dependencies": {
+    "wonka-v4": "npm:wonka@^4.0.0",
     "most": "^1.7.3",
     "rxjs": "^6.3.3"
   }

--- a/perf/suite.js
+++ b/perf/suite.js
@@ -1,4 +1,5 @@
 const Wonka = require('..');
+const Wonka4 = require('wonka-v4');
 const Rx = require('rxjs');
 const RxOperators = require('rxjs/operators');
 const most = require('most');
@@ -13,6 +14,16 @@ suite('Promisified map, filter, scan, last', () => {
       Wonka.filter(x => x > 4),
       Wonka.scan((acc, x) => acc + x, 0),
       Wonka.toPromise
+    );
+  });
+
+  benchmark('Wonka v4', () => {
+    return Wonka4.pipe(
+      Wonka4.fromArray(input),
+      Wonka4.map(x => x * 2),
+      Wonka4.filter(x => x > 4),
+      Wonka4.scan((acc, x) => acc + x, 0),
+      Wonka4.toPromise
     );
   });
 

--- a/perf/yarn.lock
+++ b/perf/yarn.lock
@@ -156,3 +156,8 @@ wcwidth@>=1.0.1:
   integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=
   dependencies:
     defaults "^1.0.3"
+
+"wonka-v4@npm:wonka@^4.0.0":
+  version "4.0.15"
+  resolved "https://registry.yarnpkg.com/wonka/-/wonka-4.0.15.tgz#9aa42046efa424565ab8f8f451fcca955bf80b89"
+  integrity sha512-U0IUQHKXXn6PFo9nqsHphVCE5m3IntqZNB9Jjn7EB1lrR7YTDY3YWgFvEvwniTzXSvOH/XMzAZaIfJF/LvHYXg==

--- a/src/__tests__/sources.test.ts
+++ b/src/__tests__/sources.test.ts
@@ -274,6 +274,7 @@ describe('fromPromise', () => {
 
     expect(signals).toEqual([start(expect.any(Function))]);
 
+    await Promise.resolve();
     await promise;
 
     expect(signals).toEqual([start(expect.any(Function)), push(1), SignalKind.End]);

--- a/src/sources.ts
+++ b/src/sources.ts
@@ -1,7 +1,7 @@
 import { Source, Sink, SignalKind, TalkbackKind, Observer, Subject, TeardownFn } from './types';
 import { push, start, talkbackPlaceholder } from './helpers';
 
-export function factory<T>(make: () => Source<T>): Source<T> {
+export function lazy<T>(make: () => Source<T>): Source<T> {
   return sink => make()(sink);
 }
 

--- a/src/sources.ts
+++ b/src/sources.ts
@@ -1,26 +1,37 @@
 import { Source, Sink, SignalKind, TalkbackKind, Observer, Subject, TeardownFn } from './types';
 import { push, start, talkbackPlaceholder } from './helpers';
 
-export function fromArray<T>(array: T[]): Source<T> {
+export function fromIterable<T>(iterable: Iterable<T>): Source<T> {
   return sink => {
+    const iterator = iterable[Symbol.iterator]();
     let ended = false;
     let looping = false;
     let pulled = false;
-    let current = 0;
+    let next: IteratorResult<T>;
     sink(
       start(signal => {
         if (signal === TalkbackKind.Close) {
           ended = true;
+          if (iterator.return) iterator.return();
         } else if (looping) {
           pulled = true;
         } else {
-          for (pulled = looping = true; pulled && !ended; current++) {
-            if (current < array.length) {
-              pulled = false;
-              sink(push(array[current]));
-            } else {
+          for (pulled = looping = true; pulled && !ended; ) {
+            if ((next = iterator.next()).done) {
               ended = true;
               sink(SignalKind.End);
+              if (iterator.return) iterator.return();
+            } else {
+              pulled = false;
+              try {
+                sink(push(next.value));
+              } catch (error) {
+                if (iterator.throw) {
+                  iterator.throw(error);
+                } else {
+                  throw error;
+                }
+              }
             }
           }
           looping = false;
@@ -29,6 +40,8 @@ export function fromArray<T>(array: T[]): Source<T> {
     );
   };
 }
+
+export const fromArray: <T>(array: T[]) => Source<T> = fromIterable;
 
 export function fromValue<T>(value: T): Source<T> {
   return sink => {


### PR DESCRIPTION
This implements a new `fromIterable` function, supporting both iterables (iterators) and async iterables. These will likely become very useful in combination with generators and async generators in JS, as a lot of complex logic _can_ be abstracted using generators, but generators fail at abstracting a couple of complex pieces of logic easily.

I'm currently not sure this is a worthwhile addition. While it does give some performance up (which to be fair, is negligible) it does add a new host of potential features.