### PR TITLE
Error opening source map

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -25,6 +25,7 @@ const plugins = [
     exclude: ['src/**/*.test.ts', '**/__tests__/*'],
     compilerOptions: {
       sourceMap: true,
+      sourceRoot: './',
       noEmit: false,
       declaration: true,
       declarationDir: './dist/types/',


### PR DESCRIPTION
Fixed an error where the Path in the source map specified the wrong location and could not be opened.
We would be happy to merge it in if you would like.