### PR TITLE
Use a ponyfill observable instead of polyfilling

### DIFF
--- a/src/observable.ts
+++ b/src/observable.ts
@@ -16,8 +16,8 @@ interface Observable<T> {
   subscribe(observer: ObservableObserver<T>): ObservableSubscription;
 }
 
-const observableSymbol = (): symbol =>
-  (Symbol as any).observable || ((Symbol as any).observable = Symbol('observable'));
+const observableSymbol = (): symbol | string =>
+  (typeof Symbol === 'function' && Symbol.observable) || '@@observable';
 
 export function fromObservable<T>(input: Observable<T>): Source<T> {
   input = input[observableSymbol()] ? (input as any)[observableSymbol()]() : input;

--- a/src/observable.ts
+++ b/src/observable.ts
@@ -16,8 +16,7 @@ interface Observable<T> {
   subscribe(observer: ObservableObserver<T>): ObservableSubscription;
 }
 
-const observableSymbol = (): symbol | string =>
-  Symbol.observable || '@@observable';
+const observableSymbol = (): symbol | string => Symbol.observable || '@@observable';
 
 export function fromObservable<T>(input: Observable<T>): Source<T> {
   input = input[observableSymbol()] ? (input as any)[observableSymbol()]() : input;

--- a/src/observable.ts
+++ b/src/observable.ts
@@ -17,7 +17,7 @@ interface Observable<T> {
 }
 
 const observableSymbol = (): symbol | string =>
-  (typeof Symbol === 'function' && Symbol.observable) || '@@observable';
+  Symbol.observable || '@@observable';
 
 export function fromObservable<T>(input: Observable<T>): Source<T> {
   input = input[observableSymbol()] ? (input as any)[observableSymbol()]() : input;


### PR DESCRIPTION
One of the issues users may run into in the current situation is that if Wonka is loaded after other Observable objects have already been created with the **pony**fill method, Wonka will polyfill the `Symbol.observable` causing packages to no longer recognise previously created observables, breaking interoperability.

This PR makes sure Wonka's behaviour matches that of other packages like [RxJS src/internal/symbol/observable.ts](https://github.com/ReactiveX/rxjs/blob/6fa819beb91ba99dadd6262d6c13f7ddfd9470c5/src/internal/symbol/observable.ts) and [redux src/utils/symbol-observable.ts](https://github.com/reduxjs/redux/blob/cf5043a4de63cb3a26dfb5e7e2d5a68d2d8a79f5/src/utils/symbol-observable.ts).