### PR TITLE
Use arrow functions instead of functions

### DIFF
--- a/src/callbag.ts
+++ b/src/callbag.ts
@@ -7,7 +7,7 @@ interface Callbag<I, O> {
   (t: 2, d?: any): void;
 }
 
-export function fromCallbag<T>(callbag: Callbag<any, T>): Source<T> {
+export const fromCallbag = <T>(callbag: Callbag<any, T>): Source<T> => {
   return sink => {
     callbag(0, (signal: number, data: any) => {
       if (signal === 0) {
@@ -23,9 +23,9 @@ export function fromCallbag<T>(callbag: Callbag<any, T>): Source<T> {
       }
     });
   };
-}
+};
 
-export function toCallbag<T>(source: Source<T>): Callbag<any, T> {
+export const toCallbag = <T>(source: Source<T>): Callbag<any, T> => {
   return (signal: number, sink: any) => {
     if (signal === 0) {
       source(signal => {
@@ -41,4 +41,4 @@ export function toCallbag<T>(source: Source<T>): Callbag<any, T> {
       });
     }
   };
-}
+};

--- a/src/combine.ts
+++ b/src/combine.ts
@@ -5,17 +5,9 @@ type TypeOfSourceArray<T extends readonly [...any[]]> = T extends [infer Head, .
   ? [TypeOfSource<Head>, ...TypeOfSourceArray<Tail>]
   : [];
 
-export function zip<Sources extends readonly [...Source<any>[]]>(
-  sources: [...Sources]
-): Source<TypeOfSourceArray<Sources>>;
-
-export function zip<Sources extends { [prop: string]: Source<any> }>(
-  sources: Sources
-): Source<{ [Property in keyof Sources]: TypeOfSource<Sources[Property]> }>;
-
-export function zip<T>(
+export const zip = (<T>(
   sources: Source<T>[] | Record<string, Source<T>>
-): Source<T[] | Record<string, T>> {
+): Source<T[] | Record<string, T>> => {
   const size = Object.keys(sources).length;
   return sink => {
     const filled: Set<string | number> = new Set();
@@ -73,10 +65,18 @@ export function zip<T>(
       })
     );
   };
-}
+}) as {
+  <Sources extends readonly [...Source<any>[]]>(sources: [...Sources]): Source<
+    TypeOfSourceArray<Sources>
+  >;
 
-export function combine<Sources extends Source<any>[]>(
+  <Sources extends { [prop: string]: Source<any> }>(sources: Sources): Source<{
+    [Property in keyof Sources]: TypeOfSource<Sources[Property]>;
+  }>;
+};
+
+export const combine = <Sources extends Source<any>[]>(
   ...sources: Sources
-): Source<TypeOfSourceArray<Sources>> {
+): Source<TypeOfSourceArray<Sources>> => {
   return zip(sources) as Source<any>;
-}
+};

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -5,14 +5,14 @@ export const teardownPlaceholder: TeardownFn = () => {
 };
 export const talkbackPlaceholder: TalkbackFn = teardownPlaceholder;
 
-export function start<T>(talkback: TalkbackFn): Start<T> {
+export const start = <T>(talkback: TalkbackFn): Start<T> => {
   const box: any = [talkback];
   box.tag = SignalKind.Start;
   return box;
-}
+};
 
-export function push<T>(value: T): Push<T> {
+export const push = <T>(value: T): Push<T> => {
   const box: any = [value];
   box.tag = SignalKind.Push;
   return box;
-}
+};

--- a/src/observable.ts
+++ b/src/observable.ts
@@ -19,7 +19,7 @@ interface Observable<T> {
 const observableSymbol = (): symbol =>
   (Symbol as any).observable || ((Symbol as any).observable = Symbol('observable'));
 
-export function fromObservable<T>(input: Observable<T>): Source<T> {
+export const fromObservable = <T>(input: Observable<T>): Source<T> => {
   input = input[observableSymbol()] ? (input as any)[observableSymbol()]() : input;
   return sink => {
     const subscription = input.subscribe({
@@ -39,9 +39,9 @@ export function fromObservable<T>(input: Observable<T>): Source<T> {
       })
     );
   };
-}
+};
 
-export function toObservable<T>(source: Source<T>): Observable<T> {
+export const toObservable = <T>(source: Source<T>): Observable<T> => {
   return {
     subscribe(observer: ObservableObserver<T>) {
       let talkback = talkbackPlaceholder;
@@ -73,4 +73,4 @@ export function toObservable<T>(source: Source<T>): Observable<T> {
       return this;
     },
   };
-}
+};

--- a/src/operators.ts
+++ b/src/operators.ts
@@ -4,7 +4,7 @@ import { fromArray } from './sources';
 
 const identity = <T>(x: T): T => x;
 
-export function buffer<S, T>(notifier: Source<S>): Operator<T, T[]> {
+export const buffer = <S, T>(notifier: Source<S>): Operator<T, T[]> => {
   return source => sink => {
     let buffer: T[] = [];
     let sourceTalkback = talkbackPlaceholder;
@@ -62,9 +62,9 @@ export function buffer<S, T>(notifier: Source<S>): Operator<T, T[]> {
       })
     );
   };
-}
+};
 
-export function concatMap<In, Out>(map: (value: In) => Source<Out>): Operator<In, Out> {
+export const concatMap = <In, Out>(map: (value: In) => Source<Out>): Operator<In, Out> => {
   return source => sink => {
     const inputQueue: In[] = [];
     let outerTalkback = talkbackPlaceholder;
@@ -73,7 +73,7 @@ export function concatMap<In, Out>(map: (value: In) => Source<Out>): Operator<In
     let innerPulled = false;
     let innerActive = false;
     let ended = false;
-    function applyInnerSource(innerSource: Source<Out>): void {
+    const applyInnerSource = (innerSource: Source<Out>): void => {
       innerActive = true;
       innerSource(signal => {
         if (signal === SignalKind.End) {
@@ -100,7 +100,7 @@ export function concatMap<In, Out>(map: (value: In) => Source<Out>): Operator<In
           }
         }
       });
-    }
+    };
     source(signal => {
       if (ended) {
         /*noop*/
@@ -142,17 +142,17 @@ export function concatMap<In, Out>(map: (value: In) => Source<Out>): Operator<In
       })
     );
   };
-}
+};
 
-export function concatAll<T>(source: Source<Source<T>>): Source<T> {
+export const concatAll = <T>(source: Source<Source<T>>): Source<T> => {
   return concatMap<Source<T>, T>(identity)(source);
-}
+};
 
-export function concat<T>(sources: Source<T>[]): Source<T> {
+export const concat = <T>(sources: Source<T>[]): Source<T> => {
   return concatAll(fromArray(sources));
-}
+};
 
-export function filter<T>(predicate: (value: T) => boolean): Operator<T, T> {
+export const filter = <T>(predicate: (value: T) => boolean): Operator<T, T> => {
   return source => sink => {
     let talkback = talkbackPlaceholder;
     source(signal => {
@@ -168,9 +168,9 @@ export function filter<T>(predicate: (value: T) => boolean): Operator<T, T> {
       }
     });
   };
-}
+};
 
-export function map<In, Out>(map: (value: In) => Out): Operator<In, Out> {
+export const map = <In, Out>(map: (value: In) => Out): Operator<In, Out> => {
   return source => sink =>
     source(signal => {
       if (signal === SignalKind.End || signal.tag === SignalKind.Start) {
@@ -179,15 +179,15 @@ export function map<In, Out>(map: (value: In) => Out): Operator<In, Out> {
         sink(push(map(signal[0])));
       }
     });
-}
+};
 
-export function mergeMap<In, Out>(map: (value: In) => Source<Out>): Operator<In, Out> {
+export const mergeMap = <In, Out>(map: (value: In) => Source<Out>): Operator<In, Out> => {
   return source => sink => {
     let innerTalkbacks: TalkbackFn[] = [];
     let outerTalkback = talkbackPlaceholder;
     let outerPulled = false;
     let ended = false;
-    function applyInnerSource(innerSource: Source<Out>): void {
+    const applyInnerSource = (innerSource: Source<Out>): void => {
       let talkback = talkbackPlaceholder;
       innerSource(signal => {
         if (signal === SignalKind.End) {
@@ -211,7 +211,7 @@ export function mergeMap<In, Out>(map: (value: In) => Source<Out>): Operator<In,
           talkback(TalkbackKind.Pull);
         }
       });
-    }
+    };
     source(signal => {
       if (ended) {
         /*noop*/
@@ -252,17 +252,17 @@ export function mergeMap<In, Out>(map: (value: In) => Source<Out>): Operator<In,
       })
     );
   };
-}
+};
 
-export function mergeAll<T>(source: Source<Source<T>>): Source<T> {
+export const mergeAll = <T>(source: Source<Source<T>>): Source<T> => {
   return mergeMap<Source<T>, T>(identity)(source);
-}
+};
 
-export function merge<T>(sources: Source<T>[]): Source<T> {
+export const merge = <T>(sources: Source<T>[]): Source<T> => {
   return mergeAll(fromArray(sources));
-}
+};
 
-export function onEnd<T>(callback: () => void): Operator<T, T> {
+export const onEnd = <T>(callback: () => void): Operator<T, T> => {
   return source => sink => {
     let ended = false;
     source(signal => {
@@ -290,9 +290,9 @@ export function onEnd<T>(callback: () => void): Operator<T, T> {
       }
     });
   };
-}
+};
 
-export function onPush<T>(callback: (value: T) => void): Operator<T, T> {
+export const onPush = <T>(callback: (value: T) => void): Operator<T, T> => {
   return source => sink => {
     let ended = false;
     source(signal => {
@@ -315,9 +315,9 @@ export function onPush<T>(callback: (value: T) => void): Operator<T, T> {
       }
     });
   };
-}
+};
 
-export function onStart<T>(callback: () => void): Operator<T, T> {
+export const onStart = <T>(callback: () => void): Operator<T, T> => {
   return source => sink =>
     source(signal => {
       if (signal === SignalKind.End) {
@@ -329,9 +329,9 @@ export function onStart<T>(callback: () => void): Operator<T, T> {
         sink(signal);
       }
     });
-}
+};
 
-export function sample<S, T>(notifier: Source<S>): Operator<T, T> {
+export const sample = <S, T>(notifier: Source<S>): Operator<T, T> => {
   return source => sink => {
     let sourceTalkback = talkbackPlaceholder;
     let notifierTalkback = talkbackPlaceholder;
@@ -387,9 +387,12 @@ export function sample<S, T>(notifier: Source<S>): Operator<T, T> {
       })
     );
   };
-}
+};
 
-export function scan<In, Out>(reducer: (acc: Out, value: In) => Out, seed: Out): Operator<In, Out> {
+export const scan = <In, Out>(
+  reducer: (acc: Out, value: In) => Out,
+  seed: Out
+): Operator<In, Out> => {
   return source => sink => {
     let acc = seed;
     source(signal => {
@@ -402,9 +405,9 @@ export function scan<In, Out>(reducer: (acc: Out, value: In) => Out, seed: Out):
       }
     });
   };
-}
+};
 
-export function share<T>(source: Source<T>): Source<T> {
+export const share = <T>(source: Source<T>): Source<T> => {
   let sinks: Sink<T>[] = [];
   let talkback = talkbackPlaceholder;
   let gotSignal = false;
@@ -436,9 +439,9 @@ export function share<T>(source: Source<T>): Source<T> {
       })
     );
   };
-}
+};
 
-export function skip<T>(wait: number): Operator<T, T> {
+export const skip = <T>(wait: number): Operator<T, T> => {
   return source => sink => {
     let talkback = talkbackPlaceholder;
     let rest = wait;
@@ -455,9 +458,9 @@ export function skip<T>(wait: number): Operator<T, T> {
       }
     });
   };
-}
+};
 
-export function skipUntil<S, T>(notifier: Source<S>): Operator<T, T> {
+export const skipUntil = <S, T>(notifier: Source<S>): Operator<T, T> => {
   return source => sink => {
     let sourceTalkback = talkbackPlaceholder;
     let notifierTalkback = talkbackPlaceholder;
@@ -511,9 +514,9 @@ export function skipUntil<S, T>(notifier: Source<S>): Operator<T, T> {
       })
     );
   };
-}
+};
 
-export function skipWhile<T>(predicate: (value: T) => boolean): Operator<T, T> {
+export const skipWhile = <T>(predicate: (value: T) => boolean): Operator<T, T> => {
   return source => sink => {
     let talkback = talkbackPlaceholder;
     let skip = true;
@@ -535,9 +538,9 @@ export function skipWhile<T>(predicate: (value: T) => boolean): Operator<T, T> {
       }
     });
   };
-}
+};
 
-export function switchMap<In, Out>(map: (value: In) => Source<Out>): Operator<In, Out> {
+export const switchMap = <In, Out>(map: (value: In) => Source<Out>): Operator<In, Out> => {
   return source => sink => {
     let outerTalkback = talkbackPlaceholder;
     let innerTalkback = talkbackPlaceholder;
@@ -545,7 +548,7 @@ export function switchMap<In, Out>(map: (value: In) => Source<Out>): Operator<In
     let innerPulled = false;
     let innerActive = false;
     let ended = false;
-    function applyInnerSource(innerSource: Source<Out>): void {
+    const applyInnerSource = (innerSource: Source<Out>): void => {
       innerActive = true;
       innerSource(signal => {
         if (!innerActive) {
@@ -570,7 +573,7 @@ export function switchMap<In, Out>(map: (value: In) => Source<Out>): Operator<In
           }
         }
       });
-    }
+    };
     source(signal => {
       if (ended) {
         /*noop*/
@@ -617,13 +620,13 @@ export function switchMap<In, Out>(map: (value: In) => Source<Out>): Operator<In
       })
     );
   };
-}
+};
 
-export function switchAll<T>(source: Source<Source<T>>): Source<T> {
+export const switchAll = <T>(source: Source<Source<T>>): Source<T> => {
   return switchMap<Source<T>, T>(identity)(source);
-}
+};
 
-export function take<T>(max: number): Operator<T, T> {
+export const take = <T>(max: number): Operator<T, T> => {
   return source => sink => {
     let talkback = talkbackPlaceholder;
     let ended = false;
@@ -664,9 +667,9 @@ export function take<T>(max: number): Operator<T, T> {
       })
     );
   };
-}
+};
 
-export function takeLast<T>(max: number): Operator<T, T> {
+export const takeLast = <T>(max: number): Operator<T, T> => {
   return source => sink => {
     const queue: T[] = [];
     let talkback = talkbackPlaceholder;
@@ -687,9 +690,9 @@ export function takeLast<T>(max: number): Operator<T, T> {
       }
     });
   };
-}
+};
 
-export function takeUntil<S, T>(notifier: Source<S>): Operator<T, T> {
+export const takeUntil = <S, T>(notifier: Source<S>): Operator<T, T> => {
   return source => sink => {
     let sourceTalkback = talkbackPlaceholder;
     let notifierTalkback = talkbackPlaceholder;
@@ -730,9 +733,9 @@ export function takeUntil<S, T>(notifier: Source<S>): Operator<T, T> {
       })
     );
   };
-}
+};
 
-export function takeWhile<T>(predicate: (value: T) => boolean): Operator<T, T> {
+export const takeWhile = <T>(predicate: (value: T) => boolean): Operator<T, T> => {
   return source => sink => {
     let talkback = talkbackPlaceholder;
     let ended = false;
@@ -754,9 +757,9 @@ export function takeWhile<T>(predicate: (value: T) => boolean): Operator<T, T> {
       }
     });
   };
-}
+};
 
-export function debounce<T>(timing: (value: T) => number): Operator<T, T> {
+export const debounce = <T>(timing: (value: T) => number): Operator<T, T> => {
   return source => sink => {
     let id: any | void;
     let deferredEnded = false;
@@ -795,9 +798,9 @@ export function debounce<T>(timing: (value: T) => number): Operator<T, T> {
       }
     });
   };
-}
+};
 
-export function delay<T>(wait: number): Operator<T, T> {
+export const delay = <T>(wait: number): Operator<T, T> => {
   return source => sink => {
     let active = 0;
     source(signal => {
@@ -814,9 +817,9 @@ export function delay<T>(wait: number): Operator<T, T> {
       }
     });
   };
-}
+};
 
-export function throttle<T>(timing: (value: T) => number): Operator<T, T> {
+export const throttle = <T>(timing: (value: T) => number): Operator<T, T> => {
   return source => sink => {
     let skip = false;
     let id: any | void;
@@ -847,6 +850,6 @@ export function throttle<T>(timing: (value: T) => number): Operator<T, T> {
       }
     });
   };
-}
+};
 
 export { mergeAll as flatten, onPush as tap };

--- a/src/pipe.ts
+++ b/src/pipe.ts
@@ -4,157 +4,138 @@ interface UnaryFn<T, R> {
   (source: T): R;
 }
 
-/* pipe definitions for source + operators composition */
+export const pipe: {
+  /* pipe definitions for source + operators composition */
+  <T, A>(source: Source<T>, op1: UnaryFn<Source<T>, Source<A>>): Source<A>;
+  <T, A, B>(
+    source: Source<T>,
+    op1: UnaryFn<Source<T>, Source<A>>,
+    op2: UnaryFn<Source<A>, Source<B>>
+  ): Source<B>;
+  <T, A, B, C>(
+    source: Source<T>,
+    op1: UnaryFn<Source<T>, Source<A>>,
+    op2: UnaryFn<Source<A>, Source<B>>,
+    op3: UnaryFn<Source<B>, Source<C>>
+  ): Source<C>;
+  <T, A, B, C, D>(
+    source: Source<T>,
+    op1: UnaryFn<Source<T>, Source<A>>,
+    op2: UnaryFn<Source<A>, Source<B>>,
+    op3: UnaryFn<Source<B>, Source<C>>,
+    op4: UnaryFn<Source<C>, Source<D>>
+  ): Source<D>;
+  <T, A, B, C, D, E>(
+    source: Source<T>,
+    op1: UnaryFn<Source<T>, Source<A>>,
+    op2: UnaryFn<Source<A>, Source<B>>,
+    op3: UnaryFn<Source<B>, Source<C>>,
+    op4: UnaryFn<Source<C>, Source<D>>,
+    op5: UnaryFn<Source<D>, Source<E>>
+  ): Source<E>;
+  <T, A, B, C, D, E, F>(
+    source: Source<T>,
+    op1: UnaryFn<Source<T>, Source<A>>,
+    op2: UnaryFn<Source<A>, Source<B>>,
+    op3: UnaryFn<Source<B>, Source<C>>,
+    op4: UnaryFn<Source<C>, Source<D>>,
+    op5: UnaryFn<Source<D>, Source<E>>,
+    op6: UnaryFn<Source<E>, Source<F>>
+  ): Source<F>;
+  <T, A, B, C, D, E, F, G>(
+    source: Source<T>,
+    op1: UnaryFn<Source<T>, Source<A>>,
+    op2: UnaryFn<Source<A>, Source<B>>,
+    op3: UnaryFn<Source<B>, Source<C>>,
+    op4: UnaryFn<Source<C>, Source<D>>,
+    op5: UnaryFn<Source<D>, Source<E>>,
+    op6: UnaryFn<Source<E>, Source<F>>,
+    op7: UnaryFn<Source<F>, Source<G>>
+  ): Source<G>;
+  <T, A, B, C, D, E, F, G, H>(
+    source: Source<T>,
+    op1: UnaryFn<Source<T>, Source<A>>,
+    op2: UnaryFn<Source<A>, Source<B>>,
+    op3: UnaryFn<Source<B>, Source<C>>,
+    op4: UnaryFn<Source<C>, Source<D>>,
+    op5: UnaryFn<Source<D>, Source<E>>,
+    op6: UnaryFn<Source<E>, Source<F>>,
+    op7: UnaryFn<Source<F>, Source<G>>,
+    op8: UnaryFn<Source<G>, Source<H>>
+  ): Source<H>;
 
-function pipe<T, A>(source: Source<T>, op1: UnaryFn<Source<T>, Source<A>>): Source<A>;
-
-function pipe<T, A, B>(
-  source: Source<T>,
-  op1: UnaryFn<Source<T>, Source<A>>,
-  op2: UnaryFn<Source<A>, Source<B>>
-): Source<B>;
-
-function pipe<T, A, B, C>(
-  source: Source<T>,
-  op1: UnaryFn<Source<T>, Source<A>>,
-  op2: UnaryFn<Source<A>, Source<B>>,
-  op3: UnaryFn<Source<B>, Source<C>>
-): Source<C>;
-
-function pipe<T, A, B, C, D>(
-  source: Source<T>,
-  op1: UnaryFn<Source<T>, Source<A>>,
-  op2: UnaryFn<Source<A>, Source<B>>,
-  op3: UnaryFn<Source<B>, Source<C>>,
-  op4: UnaryFn<Source<C>, Source<D>>
-): Source<D>;
-
-function pipe<T, A, B, C, D, E>(
-  source: Source<T>,
-  op1: UnaryFn<Source<T>, Source<A>>,
-  op2: UnaryFn<Source<A>, Source<B>>,
-  op3: UnaryFn<Source<B>, Source<C>>,
-  op4: UnaryFn<Source<C>, Source<D>>,
-  op5: UnaryFn<Source<D>, Source<E>>
-): Source<E>;
-
-function pipe<T, A, B, C, D, E, F>(
-  source: Source<T>,
-  op1: UnaryFn<Source<T>, Source<A>>,
-  op2: UnaryFn<Source<A>, Source<B>>,
-  op3: UnaryFn<Source<B>, Source<C>>,
-  op4: UnaryFn<Source<C>, Source<D>>,
-  op5: UnaryFn<Source<D>, Source<E>>,
-  op6: UnaryFn<Source<E>, Source<F>>
-): Source<F>;
-
-function pipe<T, A, B, C, D, E, F, G>(
-  source: Source<T>,
-  op1: UnaryFn<Source<T>, Source<A>>,
-  op2: UnaryFn<Source<A>, Source<B>>,
-  op3: UnaryFn<Source<B>, Source<C>>,
-  op4: UnaryFn<Source<C>, Source<D>>,
-  op5: UnaryFn<Source<D>, Source<E>>,
-  op6: UnaryFn<Source<E>, Source<F>>,
-  op7: UnaryFn<Source<F>, Source<G>>
-): Source<G>;
-
-function pipe<T, A, B, C, D, E, F, G, H>(
-  source: Source<T>,
-  op1: UnaryFn<Source<T>, Source<A>>,
-  op2: UnaryFn<Source<A>, Source<B>>,
-  op3: UnaryFn<Source<B>, Source<C>>,
-  op4: UnaryFn<Source<C>, Source<D>>,
-  op5: UnaryFn<Source<D>, Source<E>>,
-  op6: UnaryFn<Source<E>, Source<F>>,
-  op7: UnaryFn<Source<F>, Source<G>>,
-  op8: UnaryFn<Source<G>, Source<H>>
-): Source<H>;
-
-/* pipe definitions for source + operators + consumer composition */
-
-function pipe<T, R>(source: Source<T>, consumer: UnaryFn<Source<T>, R>): R;
-
-function pipe<T, A, R>(
-  source: Source<T>,
-  op1: UnaryFn<Source<T>, Source<A>>,
-  consumer: UnaryFn<Source<A>, R>
-): R;
-
-function pipe<T, A, B, R>(
-  source: Source<T>,
-  op1: UnaryFn<Source<T>, Source<A>>,
-  op2: UnaryFn<Source<A>, Source<B>>,
-  consumer: UnaryFn<Source<B>, R>
-): R;
-
-function pipe<T, A, B, C, R>(
-  source: Source<T>,
-  op1: UnaryFn<Source<T>, Source<A>>,
-  op2: UnaryFn<Source<A>, Source<B>>,
-  op3: UnaryFn<Source<B>, Source<C>>,
-  consumer: UnaryFn<Source<C>, R>
-): R;
-
-function pipe<T, A, B, C, D, R>(
-  source: Source<T>,
-  op1: UnaryFn<Source<T>, Source<A>>,
-  op2: UnaryFn<Source<A>, Source<B>>,
-  op3: UnaryFn<Source<B>, Source<C>>,
-  op4: UnaryFn<Source<C>, Source<D>>,
-  consumer: UnaryFn<Source<D>, R>
-): R;
-
-function pipe<T, A, B, C, D, E, R>(
-  source: Source<T>,
-  op1: UnaryFn<Source<T>, Source<A>>,
-  op2: UnaryFn<Source<A>, Source<B>>,
-  op3: UnaryFn<Source<B>, Source<C>>,
-  op4: UnaryFn<Source<C>, Source<D>>,
-  op5: UnaryFn<Source<D>, Source<E>>,
-  consumer: UnaryFn<Source<E>, R>
-): R;
-
-function pipe<T, A, B, C, D, E, F, R>(
-  source: Source<T>,
-  op1: UnaryFn<Source<T>, Source<A>>,
-  op2: UnaryFn<Source<A>, Source<B>>,
-  op3: UnaryFn<Source<B>, Source<C>>,
-  op4: UnaryFn<Source<C>, Source<D>>,
-  op5: UnaryFn<Source<D>, Source<E>>,
-  op6: UnaryFn<Source<E>, Source<F>>,
-  consumer: UnaryFn<Source<F>, R>
-): R;
-
-function pipe<T, A, B, C, D, E, F, G, R>(
-  source: Source<T>,
-  op1: UnaryFn<Source<T>, Source<A>>,
-  op2: UnaryFn<Source<A>, Source<B>>,
-  op3: UnaryFn<Source<B>, Source<C>>,
-  op4: UnaryFn<Source<C>, Source<D>>,
-  op5: UnaryFn<Source<D>, Source<E>>,
-  op6: UnaryFn<Source<E>, Source<F>>,
-  op7: UnaryFn<Source<F>, Source<G>>,
-  consumer: UnaryFn<Source<G>, R>
-): R;
-
-function pipe<T, A, B, C, D, E, F, G, H, R>(
-  source: Source<T>,
-  op1: UnaryFn<Source<T>, Source<A>>,
-  op2: UnaryFn<Source<A>, Source<B>>,
-  op3: UnaryFn<Source<B>, Source<C>>,
-  op4: UnaryFn<Source<C>, Source<D>>,
-  op5: UnaryFn<Source<D>, Source<E>>,
-  op6: UnaryFn<Source<E>, Source<F>>,
-  op7: UnaryFn<Source<F>, Source<G>>,
-  op8: UnaryFn<Source<G>, Source<H>>,
-  consumer: UnaryFn<Source<H>, R>
-): R;
-
-function pipe(...args: any[]) {
+  /* pipe definitions for source + operators + consumer composition */
+  <T, R>(source: Source<T>, consumer: UnaryFn<Source<T>, R>): R;
+  <T, A, R>(
+    source: Source<T>,
+    op1: UnaryFn<Source<T>, Source<A>>,
+    consumer: UnaryFn<Source<A>, R>
+  ): R;
+  <T, A, B, R>(
+    source: Source<T>,
+    op1: UnaryFn<Source<T>, Source<A>>,
+    op2: UnaryFn<Source<A>, Source<B>>,
+    consumer: UnaryFn<Source<B>, R>
+  ): R;
+  <T, A, B, C, R>(
+    source: Source<T>,
+    op1: UnaryFn<Source<T>, Source<A>>,
+    op2: UnaryFn<Source<A>, Source<B>>,
+    op3: UnaryFn<Source<B>, Source<C>>,
+    consumer: UnaryFn<Source<C>, R>
+  ): R;
+  <T, A, B, C, D, R>(
+    source: Source<T>,
+    op1: UnaryFn<Source<T>, Source<A>>,
+    op2: UnaryFn<Source<A>, Source<B>>,
+    op3: UnaryFn<Source<B>, Source<C>>,
+    op4: UnaryFn<Source<C>, Source<D>>,
+    consumer: UnaryFn<Source<D>, R>
+  ): R;
+  <T, A, B, C, D, E, R>(
+    source: Source<T>,
+    op1: UnaryFn<Source<T>, Source<A>>,
+    op2: UnaryFn<Source<A>, Source<B>>,
+    op3: UnaryFn<Source<B>, Source<C>>,
+    op4: UnaryFn<Source<C>, Source<D>>,
+    op5: UnaryFn<Source<D>, Source<E>>,
+    consumer: UnaryFn<Source<E>, R>
+  ): R;
+  <T, A, B, C, D, E, F, R>(
+    source: Source<T>,
+    op1: UnaryFn<Source<T>, Source<A>>,
+    op2: UnaryFn<Source<A>, Source<B>>,
+    op3: UnaryFn<Source<B>, Source<C>>,
+    op4: UnaryFn<Source<C>, Source<D>>,
+    op5: UnaryFn<Source<D>, Source<E>>,
+    op6: UnaryFn<Source<E>, Source<F>>,
+    consumer: UnaryFn<Source<F>, R>
+  ): R;
+  <T, A, B, C, D, E, F, G, R>(
+    source: Source<T>,
+    op1: UnaryFn<Source<T>, Source<A>>,
+    op2: UnaryFn<Source<A>, Source<B>>,
+    op3: UnaryFn<Source<B>, Source<C>>,
+    op4: UnaryFn<Source<C>, Source<D>>,
+    op5: UnaryFn<Source<D>, Source<E>>,
+    op6: UnaryFn<Source<E>, Source<F>>,
+    op7: UnaryFn<Source<F>, Source<G>>,
+    consumer: UnaryFn<Source<G>, R>
+  ): R;
+  <T, A, B, C, D, E, F, G, H, R>(
+    source: Source<T>,
+    op1: UnaryFn<Source<T>, Source<A>>,
+    op2: UnaryFn<Source<A>, Source<B>>,
+    op3: UnaryFn<Source<B>, Source<C>>,
+    op4: UnaryFn<Source<C>, Source<D>>,
+    op5: UnaryFn<Source<D>, Source<E>>,
+    op6: UnaryFn<Source<E>, Source<F>>,
+    op7: UnaryFn<Source<F>, Source<G>>,
+    op8: UnaryFn<Source<G>, Source<H>>,
+    consumer: UnaryFn<Source<H>, R>
+  ): R;
+} = (...args: any[]) => {
   let x = args[0];
   for (let i = 1, l = args.length; i < l; i++) x = args[i](x);
   return x;
-}
-
-export { pipe };
+};

--- a/src/sinks.ts
+++ b/src/sinks.ts
@@ -1,7 +1,7 @@
 import { Source, Subscription, TalkbackKind, SignalKind } from './types';
 import { talkbackPlaceholder } from './helpers';
 
-export function subscribe<T>(subscriber: (value: T) => void) {
+export const subscribe = <T>(subscriber: (value: T) => void) => {
   return (source: Source<T>): Subscription => {
     let talkback = talkbackPlaceholder;
     let ended = false;
@@ -24,21 +24,21 @@ export function subscribe<T>(subscriber: (value: T) => void) {
       },
     };
   };
-}
+};
 
-export function forEach<T>(subscriber: (value: T) => void) {
+export const forEach = <T>(subscriber: (value: T) => void) => {
   return (source: Source<T>): void => {
     subscribe(subscriber)(source);
   };
-}
+};
 
-export function publish<T>(source: Source<T>): void {
+export const publish = <T>(source: Source<T>): void => {
   subscribe(_value => {
     /*noop*/
   })(source);
-}
+};
 
-export function toArray<T>(source: Source<T>): T[] {
+export const toArray = <T>(source: Source<T>): T[] => {
   const values: T[] = [];
   let talkback = talkbackPlaceholder;
   let ended = false;
@@ -54,9 +54,9 @@ export function toArray<T>(source: Source<T>): T[] {
   });
   if (!ended) talkback(TalkbackKind.Close);
   return values;
-}
+};
 
-export function toPromise<T>(source: Source<T>): Promise<T> {
+export const toPromise = <T>(source: Source<T>): Promise<T> => {
   return new Promise(resolve => {
     let talkback = talkbackPlaceholder;
     let value: T | void;
@@ -71,4 +71,4 @@ export function toPromise<T>(source: Source<T>): Promise<T> {
       }
     });
   });
-}
+};

--- a/src/sources.ts
+++ b/src/sources.ts
@@ -2,11 +2,11 @@ import { Source, Sink, SignalKind, TalkbackKind, Observer, Subject, TeardownFn }
 import { push, start, talkbackPlaceholder, teardownPlaceholder } from './helpers';
 import { share } from './operators';
 
-export function lazy<T>(make: () => Source<T>): Source<T> {
+export const lazy = <T>(make: () => Source<T>): Source<T> => {
   return sink => make()(sink);
-}
+};
 
-export function fromAsyncIterable<T>(iterable: AsyncIterable<T>): Source<T> {
+export const fromAsyncIterable = <T>(iterable: AsyncIterable<T>): Source<T> => {
   return sink => {
     const iterator = iterable[Symbol.asyncIterator]();
     let ended = false;
@@ -44,9 +44,9 @@ export function fromAsyncIterable<T>(iterable: AsyncIterable<T>): Source<T> {
       })
     );
   };
-}
+};
 
-export function fromIterable<T>(iterable: Iterable<T> | AsyncIterable<T>): Source<T> {
+export const fromIterable = <T>(iterable: Iterable<T> | AsyncIterable<T>): Source<T> => {
   if (iterable[Symbol.asyncIterator]) return fromAsyncIterable(iterable as AsyncIterable<T>);
   return sink => {
     const iterator = iterable[Symbol.iterator]();
@@ -85,11 +85,11 @@ export function fromIterable<T>(iterable: Iterable<T> | AsyncIterable<T>): Sourc
       })
     );
   };
-}
+};
 
 export const fromArray: <T>(array: T[]) => Source<T> = fromIterable;
 
-export function fromValue<T>(value: T): Source<T> {
+export const fromValue = <T>(value: T): Source<T> => {
   return sink => {
     let ended = false;
     sink(
@@ -104,9 +104,9 @@ export function fromValue<T>(value: T): Source<T> {
       })
     );
   };
-}
+};
 
-export function make<T>(produce: (observer: Observer<T>) => TeardownFn): Source<T> {
+export const make = <T>(produce: (observer: Observer<T>) => TeardownFn): Source<T> => {
   return sink => {
     let ended = false;
     const teardown = produce({
@@ -129,9 +129,9 @@ export function make<T>(produce: (observer: Observer<T>) => TeardownFn): Source<
       })
     );
   };
-}
+};
 
-export function makeSubject<T>(): Subject<T> {
+export const makeSubject = <T>(): Subject<T> => {
   let next: Subject<T>['next'] | void;
   let complete: Subject<T>['complete'] | void;
   return {
@@ -149,7 +149,7 @@ export function makeSubject<T>(): Subject<T> {
       if (complete) complete();
     },
   };
-}
+};
 
 export const empty: Source<any> = (sink: Sink<any>): void => {
   let ended = false;
@@ -169,22 +169,22 @@ export const never: Source<any> = (sink: Sink<any>): void => {
   sink(start(talkbackPlaceholder));
 };
 
-export function interval(ms: number): Source<number> {
+export const interval = (ms: number): Source<number> => {
   return make(observer => {
     let i = 0;
     const id = setInterval(() => observer.next(i++), ms);
     return () => clearInterval(id);
   });
-}
+};
 
-export function fromDomEvent(element: HTMLElement, event: string): Source<Event> {
+export const fromDomEvent = (element: HTMLElement, event: string): Source<Event> => {
   return make(observer => {
     element.addEventListener(event, observer.next);
     return () => element.removeEventListener(event, observer.next);
   });
-}
+};
 
-export function fromPromise<T>(promise: Promise<T>): Source<T> {
+export const fromPromise = <T>(promise: Promise<T>): Source<T> => {
   return make(observer => {
     promise.then(value => {
       Promise.resolve(value).then(() => {
@@ -194,4 +194,4 @@ export function fromPromise<T>(promise: Promise<T>): Source<T> {
     });
     return teardownPlaceholder;
   });
-}
+};


### PR DESCRIPTION
There doesn't seem to be a need for actual functions anywhere. Might be convenient to just use arrow functions instead. I can do the other solution with `this: void` instead if you'd prefer that. Let me know!

So, `zip` got a little weirder with this solution but everything else looks quite good.

Fixes #123