### PR TITLE
fix: Add missing Close signal to takeUntil operator

### DIFF
--- a/src/operators.ts
+++ b/src/operators.ts
@@ -710,6 +710,7 @@ export function takeUntil<S, T>(notifier: Source<S>): Operator<T, T> {
             (notifierTalkback = signal[0])(TalkbackKind.Pull);
           } else {
             ended = true;
+            notifierTalkback(TalkbackKind.Close);
             sourceTalkback(TalkbackKind.Close);
             sink(SignalKind.End);
           }


### PR DESCRIPTION
Adds missing `Close` signal to `takeUntil` when notifier receives a `Push` event.