### PR TITLE
fix: Add missing Promise.resolve() tick to toPromise

### DIFF
--- a/.changeset/eleven-candles-rest.md
+++ b/.changeset/eleven-candles-rest.md
@@ -1,0 +1,5 @@
+---
+'wonka': patch
+---
+
+Fix promise timing by adding missing `Promise.resolve()` tick to `toPromise` sink function.

--- a/src/sinks.ts
+++ b/src/sinks.ts
@@ -62,7 +62,7 @@ export function toPromise<T>(source: Source<T>): Promise<T> {
     let value: T | void;
     source(signal => {
       if (signal === SignalKind.End) {
-        resolve(value!);
+        Promise.resolve(value!).then(resolve);
       } else if (signal.tag === SignalKind.Start) {
         (talkback = signal[0])(TalkbackKind.Pull);
       } else {


### PR DESCRIPTION
Add missing `Promise.resolve(value).then(...)` tick to the `toPromise` helper, as has been done in `@urql/core`.