### PR TITLE
feat: Completely fulfill the Observable spec in toObservable

### DIFF
--- a/.changeset/seven-meals-film.md
+++ b/.changeset/seven-meals-film.md
@@ -1,0 +1,5 @@
+---
+'wonka': patch
+---
+
+Fix implementation of Observable spec as such that Observable.subscribe(onNext, onError, onComplete) becomes valid.


### PR DESCRIPTION
The [Observable spec](https://github.com/tc39/proposal-observable#observable) should be completely fulfilled in the implementation of `toObservable`.

Specifically, the `subscribe` function must accept `subscribe(onNext, onError, onComplete` in its implementation, rather than just `subscribe(observer)`