### PR TITLE
feat: Implement toAsyncIterable

### DIFF
--- a/.changeset/beige-worms-help.md
+++ b/.changeset/beige-worms-help.md
@@ -1,0 +1,5 @@
+---
+'wonka': minor
+---
+
+Implement `toAsyncIterable`, converting a Wonka source to a JS Async Iterable.

--- a/src/sinks.ts
+++ b/src/sinks.ts
@@ -57,8 +57,7 @@ export const toAsyncIterable = <T>(source: Source<T>): AsyncIterable<T> => ({
       } else if (signal.tag === SignalKind.Start) {
         (talkback = signal[0])(TalkbackKind.Pull);
       } else if (next) {
-        next({ value: signal[0], done: false });
-        next = undefined;
+        next = next({ value: signal[0], done: false });
       } else {
         buffer.push(signal[0]);
       }

--- a/src/sinks.ts
+++ b/src/sinks.ts
@@ -50,7 +50,9 @@ export function toAsyncIterable<T>(source: Source<T>): AsyncIterable<T> {
       let next: ((value: IteratorResult<T>) => void) | undefined;
 
       source(signal => {
-        if (signal === SignalKind.End) {
+        if (ended) {
+          /*noop*/
+        } else if (signal === SignalKind.End) {
           if (next) {
             next(doneResult);
             next = undefined;

--- a/src/sinks.ts
+++ b/src/sinks.ts
@@ -40,57 +40,50 @@ export function publish<T>(source: Source<T>): void {
 
 const doneResult = { done: true } as IteratorReturnResult<void>;
 
-export function toAsyncIterable<T>(source: Source<T>): AsyncIterable<T> {
-  return {
-    [Symbol.asyncIterator](): AsyncIterator<T> {
-      const buffer: T[] = [];
+export const toAsyncIterable = <T>(source: Source<T>): AsyncIterable<T> => ({
+  [Symbol.asyncIterator](): AsyncIterator<T> {
+    const buffer: T[] = [];
 
-      let ended = false;
-      let talkback = talkbackPlaceholder;
-      let next: ((value: IteratorResult<T>) => void) | undefined;
+    let ended = false;
+    let talkback = talkbackPlaceholder;
+    let next: ((value: IteratorResult<T>) => void) | void;
 
-      source(signal => {
-        if (ended) {
-          /*noop*/
-        } else if (signal === SignalKind.End) {
-          if (next) {
-            next(doneResult);
-            next = undefined;
-          }
-          ended = true;
-        } else if (signal.tag === SignalKind.Start) {
-          (talkback = signal[0])(TalkbackKind.Pull);
-        } else if (next) {
-          next({ value: signal[0], done: false });
-          next = undefined;
-        } else {
-          buffer.push(signal[0]);
-        }
-      });
+    source(signal => {
+      if (ended) {
+        /*noop*/
+      } else if (signal === SignalKind.End) {
+        if (next) next = next(doneResult);
+        ended = true;
+      } else if (signal.tag === SignalKind.Start) {
+        (talkback = signal[0])(TalkbackKind.Pull);
+      } else if (next) {
+        next({ value: signal[0], done: false });
+        next = undefined;
+      } else {
+        buffer.push(signal[0]);
+      }
+    });
 
-      return {
-        async next(): Promise<IteratorResult<T>> {
-          if (ended && !buffer.length) {
-            return doneResult;
-          } else if (!ended && buffer.length <= 1) {
-            talkback(TalkbackKind.Pull);
-          }
-
-          return buffer.length
-            ? { value: buffer.shift()!, done: false }
-            : new Promise(resolve => {
-                next = resolve;
-              });
-        },
-        async return(): Promise<IteratorReturnResult<void>> {
-          if (!ended) talkback(TalkbackKind.Close);
-          ended = true;
+    return {
+      async next(): Promise<IteratorResult<T>> {
+        if (ended && !buffer.length) {
           return doneResult;
-        },
-      };
-    },
-  };
-}
+        } else if (!ended && buffer.length <= 1) {
+          talkback(TalkbackKind.Pull);
+        }
+
+        return buffer.length
+          ? { value: buffer.shift()!, done: false }
+          : new Promise(resolve => (next = resolve));
+      },
+      async return(): Promise<IteratorReturnResult<void>> {
+        if (!ended) next = talkback(TalkbackKind.Close);
+        ended = true;
+        return doneResult;
+      },
+    };
+  },
+});
 
 export function toArray<T>(source: Source<T>): T[] {
   const values: T[] = [];

--- a/src/sinks.ts
+++ b/src/sinks.ts
@@ -69,9 +69,9 @@ export function toAsyncIterable<T>(source: Source<T>): AsyncIterable<T> {
 
       return {
         async next(): Promise<IteratorResult<T>> {
-          if (ended) {
+          if (ended && !buffer.length) {
             return doneResult;
-          } else if (!buffer.length) {
+          } else if (!ended && buffer.length <= 1) {
             talkback(TalkbackKind.Pull);
           }
 

--- a/src/sinks.ts
+++ b/src/sinks.ts
@@ -59,8 +59,7 @@ export function toAsyncIterable<T>(source: Source<T>): AsyncIterable<T> {
           }
           ended = true;
         } else if (signal.tag === SignalKind.Start) {
-          talkback = signal[0];
-          if (!buffer.length) talkback(TalkbackKind.Pull);
+          (talkback = signal[0])(TalkbackKind.Pull);
         } else if (next) {
           next({ value: signal[0], done: false });
           next = undefined;


### PR DESCRIPTION
This implements a `toAsyncIterable` helper, as per the ECMAScript spec and protocol. The return `AsyncIterable` creates an `AsyncIterator` when `[Symbol.asyncIterator]` is called, as per the spec.

This supersedes #125