### PR TITLE
fix: Add Symbol.observable typings and isolate const enums

### DIFF
--- a/.changeset/new-feet-sell.md
+++ b/.changeset/new-feet-sell.md
@@ -1,0 +1,5 @@
+---
+'wonka': patch
+---
+
+Fix missing `Symbol.observable` typings and remove `const enum` exports, which aren't usable in isolated modules.

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "rollup-plugin-cjs-check": "^1.0.1",
     "rollup-plugin-dts": "^5.1.1",
     "tslib": "^2.4.1",
-    "typescript": "^4.9.3",
+    "typescript": "^4.9.5",
     "vitest": "^0.25.3",
     "zen-observable": "^0.10.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,7 +30,7 @@ specifiers:
   rollup-plugin-cjs-check: ^1.0.1
   rollup-plugin-dts: ^5.1.1
   tslib: ^2.4.1
-  typescript: ^4.9.3
+  typescript: ^4.9.5
   vitest: ^0.25.3
   zen-observable: ^0.10.0
 
@@ -41,11 +41,11 @@ devDependencies:
   '@rollup/plugin-commonjs': 23.0.3_rollup@3.5.1
   '@rollup/plugin-node-resolve': 15.0.1_rollup@3.5.1
   '@rollup/plugin-terser': 0.1.0_rollup@3.5.1
-  '@rollup/plugin-typescript': 10.0.1_3d7bvrhnnvjmhphi3zgbz54owe
+  '@rollup/plugin-typescript': 10.0.1_i353se4wjqegof6rzgogenttmu
   '@rollup/pluginutils': 5.0.2_rollup@3.5.1
   '@types/zen-observable': 0.8.3
-  '@typescript-eslint/eslint-plugin': 5.45.0_yjegg5cyoezm3fzsmuszzhetym
-  '@typescript-eslint/parser': 5.45.0_s5ps7njkmjlaqajutnox5ntcla
+  '@typescript-eslint/eslint-plugin': 5.45.0_kmw7swegqdzhqtxnpydwp4nxvm
+  '@typescript-eslint/parser': 5.45.0_zbm6mgjew7sm4ssghrxdqoiad4
   callbag-from-iter: 1.3.0
   callbag-iterate: 1.0.0
   callbag-take: 1.5.0
@@ -62,9 +62,9 @@ devDependencies:
   rimraf: 3.0.2
   rollup: 3.5.1
   rollup-plugin-cjs-check: 1.0.1_rollup@3.5.1
-  rollup-plugin-dts: 5.1.1_rt6svyh24sgpogwv5hms77uhpq
+  rollup-plugin-dts: 5.1.1_7qkzlat3umsxdjhtme2mo4o6km
   tslib: 2.4.1
-  typescript: 4.9.3
+  typescript: 4.9.5
   vitest: 0.25.3
   zen-observable: 0.10.0
 
@@ -500,7 +500,7 @@ packages:
       terser: 5.16.1
     dev: true
 
-  /@rollup/plugin-typescript/10.0.1_3d7bvrhnnvjmhphi3zgbz54owe:
+  /@rollup/plugin-typescript/10.0.1_i353se4wjqegof6rzgogenttmu:
     resolution: {integrity: sha512-wBykxRLlX7EzL8BmUqMqk5zpx2onnmRMSw/l9M1sVfkJvdwfxogZQVNUM9gVMJbjRLDR5H6U0OMOrlDGmIV45A==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -517,7 +517,7 @@ packages:
       resolve: 1.22.1
       rollup: 3.5.1
       tslib: 2.4.1
-      typescript: 4.9.3
+      typescript: 4.9.5
     dev: true
 
   /@rollup/pluginutils/5.0.2_rollup@3.5.1:
@@ -601,7 +601,7 @@ packages:
     resolution: {integrity: sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw==}
     dev: true
 
-  /@typescript-eslint/eslint-plugin/5.45.0_yjegg5cyoezm3fzsmuszzhetym:
+  /@typescript-eslint/eslint-plugin/5.45.0_kmw7swegqdzhqtxnpydwp4nxvm:
     resolution: {integrity: sha512-CXXHNlf0oL+Yg021cxgOdMHNTXD17rHkq7iW6RFHoybdFgQBjU3yIXhhcPpGwr1CjZlo6ET8C6tzX5juQoXeGA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -612,23 +612,23 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.45.0_s5ps7njkmjlaqajutnox5ntcla
+      '@typescript-eslint/parser': 5.45.0_zbm6mgjew7sm4ssghrxdqoiad4
       '@typescript-eslint/scope-manager': 5.45.0
-      '@typescript-eslint/type-utils': 5.45.0_s5ps7njkmjlaqajutnox5ntcla
-      '@typescript-eslint/utils': 5.45.0_s5ps7njkmjlaqajutnox5ntcla
+      '@typescript-eslint/type-utils': 5.45.0_zbm6mgjew7sm4ssghrxdqoiad4
+      '@typescript-eslint/utils': 5.45.0_zbm6mgjew7sm4ssghrxdqoiad4
       debug: 4.3.4
       eslint: 8.29.0
       ignore: 5.2.1
       natural-compare-lite: 1.4.0
       regexpp: 3.2.0
       semver: 7.3.8
-      tsutils: 3.21.0_typescript@4.9.3
-      typescript: 4.9.3
+      tsutils: 3.21.0_typescript@4.9.5
+      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser/5.45.0_s5ps7njkmjlaqajutnox5ntcla:
+  /@typescript-eslint/parser/5.45.0_zbm6mgjew7sm4ssghrxdqoiad4:
     resolution: {integrity: sha512-brvs/WSM4fKUmF5Ot/gEve6qYiCMjm6w4HkHPfS6ZNmxTS0m0iNN4yOChImaCkqc1hRwFGqUyanMXuGal6oyyQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -640,10 +640,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.45.0
       '@typescript-eslint/types': 5.45.0
-      '@typescript-eslint/typescript-estree': 5.45.0_typescript@4.9.3
+      '@typescript-eslint/typescript-estree': 5.45.0_typescript@4.9.5
       debug: 4.3.4
       eslint: 8.29.0
-      typescript: 4.9.3
+      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -656,7 +656,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.45.0
     dev: true
 
-  /@typescript-eslint/type-utils/5.45.0_s5ps7njkmjlaqajutnox5ntcla:
+  /@typescript-eslint/type-utils/5.45.0_zbm6mgjew7sm4ssghrxdqoiad4:
     resolution: {integrity: sha512-DY7BXVFSIGRGFZ574hTEyLPRiQIvI/9oGcN8t1A7f6zIs6ftbrU0nhyV26ZW//6f85avkwrLag424n+fkuoJ1Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -666,12 +666,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.45.0_typescript@4.9.3
-      '@typescript-eslint/utils': 5.45.0_s5ps7njkmjlaqajutnox5ntcla
+      '@typescript-eslint/typescript-estree': 5.45.0_typescript@4.9.5
+      '@typescript-eslint/utils': 5.45.0_zbm6mgjew7sm4ssghrxdqoiad4
       debug: 4.3.4
       eslint: 8.29.0
-      tsutils: 3.21.0_typescript@4.9.3
-      typescript: 4.9.3
+      tsutils: 3.21.0_typescript@4.9.5
+      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -681,7 +681,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree/5.45.0_typescript@4.9.3:
+  /@typescript-eslint/typescript-estree/5.45.0_typescript@4.9.5:
     resolution: {integrity: sha512-maRhLGSzqUpFcZgXxg1qc/+H0bT36lHK4APhp0AEUVrpSwXiRAomm/JGjSG+kNUio5kAa3uekCYu/47cnGn5EQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -696,13 +696,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.8
-      tsutils: 3.21.0_typescript@4.9.3
-      typescript: 4.9.3
+      tsutils: 3.21.0_typescript@4.9.5
+      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils/5.45.0_s5ps7njkmjlaqajutnox5ntcla:
+  /@typescript-eslint/utils/5.45.0_zbm6mgjew7sm4ssghrxdqoiad4:
     resolution: {integrity: sha512-OUg2JvsVI1oIee/SwiejTot2OxwU8a7UfTFMOdlhD2y+Hl6memUSL4s98bpUTo8EpVEr0lmwlU7JSu/p2QpSvA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -712,7 +712,7 @@ packages:
       '@types/semver': 7.3.13
       '@typescript-eslint/scope-manager': 5.45.0
       '@typescript-eslint/types': 5.45.0
-      '@typescript-eslint/typescript-estree': 5.45.0_typescript@4.9.3
+      '@typescript-eslint/typescript-estree': 5.45.0_typescript@4.9.5
       eslint: 8.29.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@8.29.0
@@ -3149,7 +3149,7 @@ packages:
       rollup: 3.5.1
     dev: true
 
-  /rollup-plugin-dts/5.1.1_rt6svyh24sgpogwv5hms77uhpq:
+  /rollup-plugin-dts/5.1.1_7qkzlat3umsxdjhtme2mo4o6km:
     resolution: {integrity: sha512-zpgo52XmnLg8w4k3MScinFHZK1+ro6r7uVe34fJ0Ee8AM45FvgvTuvfWWaRgIpA4pQ1BHJuu2ospncZhkcJVeA==}
     engines: {node: '>=v14'}
     peerDependencies:
@@ -3158,7 +3158,7 @@ packages:
     dependencies:
       magic-string: 0.27.0
       rollup: 3.5.1
-      typescript: 4.9.3
+      typescript: 4.9.5
     optionalDependencies:
       '@babel/code-frame': 7.18.6
     dev: true
@@ -3562,14 +3562,14 @@ packages:
     resolution: {integrity: sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==}
     dev: true
 
-  /tsutils/3.21.0_typescript@4.9.3:
+  /tsutils/3.21.0_typescript@4.9.5:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 4.9.3
+      typescript: 4.9.5
     dev: true
 
   /tty-table/4.1.6:
@@ -3633,8 +3633,8 @@ packages:
     hasBin: true
     dev: true
 
-  /typescript/4.9.3:
-    resolution: {integrity: sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==}
+  /typescript/4.9.5:
+    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: true

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,18 @@
  * @packageDocumentation
  */
 
-export * from './types';
+export type {
+  TeardownFn,
+  Signal,
+  Sink,
+  Source,
+  Operator,
+  TypeOfSource,
+  Subscription,
+  Observer,
+  Subject,
+} from './types';
+
 export * from './sources';
 export * from './operators';
 export * from './sinks';

--- a/src/observable.ts
+++ b/src/observable.ts
@@ -1,6 +1,12 @@
 import { Source, SignalKind, TalkbackKind } from './types';
 import { push, start, talkbackPlaceholder } from './helpers';
 
+declare global {
+  interface SymbolConstructor {
+    readonly observable: symbol;
+  }
+}
+
 /** A definition of the ES Observable Subscription type that is returned by
  * {@link Observable.subscribe}
  *
@@ -124,7 +130,8 @@ interface Observable<T> {
  *
  * @internal
  */
-const observableSymbol = (): typeof Symbol.observable => Symbol.observable || '@@observable';
+const observableSymbol = (): typeof Symbol.observable =>
+  Symbol.observable || ('@@observable' as any);
 
 /** Converts an ES Observable to a {@link Source}.
  * @param input - The {@link ObservableLike} object that will be converted.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "forceConsistentCasingInFileNames": true,
+    "importsNotUsedAsValues": "remove",
     "noEmit": true,
     "esModuleInterop": true,
     "noUnusedLocals": true,
@@ -16,7 +17,8 @@
     "strict": true,
     "noImplicitAny": false,
     "noUnusedParameters": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "isolatedModules": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
Resolve #5814

This adds changes missing related to:
- the `Observable` typings changes,
- the isolated const enums,
- and changes how the bundled typings are generated