### PR TITLE
Add exports willdcard using new (Node 17+) notation

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
       "source": "./src/Wonka.ts"
     },
     "./package.json": "./package.json",
-    "./": "./"
+    "./": "./*"
   },
   "sideEffects": false,
   "files": [


### PR DESCRIPTION
The issue in #97 (['ERR_PACKAGE_PATH_NOT_EXPORTED')appears to be back in Node 18. 

I believe that Node 17 deprecated the ` "./": "./"` wildcard notation in the exports section of package.json, so I've added it using the new style.