### PR TITLE
update package.json to follow docs + disable sourceMap in prod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,8 @@ name: CI
 on:
   pull_request:
   push:
-    branches: main
+    branches:
+      - main
 
 jobs:
   check:

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 dist/
 package-lock.json
 .DS_Store
+*.tgz
+.eslintcache
+__ignore__

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+enable-pre-post-scripts=true

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "6.2.3",
   "author": "0no.co <hi@0no.co>",
   "source": "./src/index.ts",
-  "main": "./dist/wonka/index.js",
+  "main": "./dist/wonka.js",
   "module": "./dist/wonka.mjs",
   "types": "./dist/wonka.d.ts",
   "exports": {
@@ -37,10 +37,12 @@
     "check": "tsc",
     "lint": "eslint . --ext=js,cjs,mjs,ts --cache",
     "lint:fix": "eslint . --ext=js,cjs,mjs,ts --fix --cache",
+    "prebuild": "rimraf dist",
     "build": "rollup -c scripts/rollup.config.mjs",
     "clean": "rimraf dist node_modules/.cache",
     "prepublishOnly": "run-s clean build check test",
-    "prepare": "node ./scripts/prepare.js"
+    "prepare": "node ./scripts/prepare.js",
+    "publish-dry-run": "pnpm publish --dry-run --no-git-checks"
   },
   "repository": "https://github.com/0no-co/wonka",
   "bugs": {
@@ -79,6 +81,7 @@
     "@rollup/plugin-terser": "^0.1.0",
     "@rollup/plugin-typescript": "^10.0.1",
     "@rollup/pluginutils": "^5.0.2",
+    "@types/node": "^18.14.2",
     "@types/zen-observable": "^0.8.3",
     "@typescript-eslint/eslint-plugin": "^5.45.0",
     "@typescript-eslint/parser": "^5.45.0",
@@ -99,9 +102,8 @@
     "rollup": "^3.5.1",
     "rollup-plugin-cjs-check": "^1.0.1",
     "rollup-plugin-dts": "^5.1.1",
-    "tslib": "^2.4.1",
     "typescript": "^4.9.5",
-    "vitest": "^0.25.3",
+    "vitest": "^0.29.2",
     "zen-observable": "^0.10.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,21 +4,19 @@
   "version": "6.2.3",
   "author": "0no.co <hi@0no.co>",
   "source": "./src/index.ts",
-  "main": "./dist/wonka",
+  "main": "./dist/wonka/index.js",
   "module": "./dist/wonka.mjs",
   "types": "./dist/wonka.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/wonka.mjs",
-      "require": "./dist/wonka.js",
       "types": "./dist/wonka.d.ts",
-      "source": "./src/index.ts"
+      "import": "./dist/wonka.mjs",
+      "require": "./dist/wonka.js"
     },
     "./package.json": "./package.json"
   },
   "sideEffects": false,
   "files": [
-    "src",
     "dist",
     "docs/*.md",
     "index.js.flow",
@@ -37,7 +35,8 @@
   "scripts": {
     "test": "vitest run",
     "check": "tsc",
-    "lint": "eslint --ext=js,ts .",
+    "lint": "eslint . --ext=js,cjs,mjs,ts --cache",
+    "lint:fix": "eslint . --ext=js,cjs,mjs,ts --fix --cache",
     "build": "rollup -c scripts/rollup.config.mjs",
     "clean": "rimraf dist node_modules/.cache",
     "prepublishOnly": "run-s clean build check test",
@@ -51,7 +50,9 @@
   "prettier": {
     "singleQuote": true,
     "tabWidth": 2,
-    "printWidth": 100
+    "printWidth": 100,
+    "arrowParens": "avoid",
+    "trailingComma": "es5"
   },
   "lint-staged": {
     "*.{ts,js}": "eslint -c scripts/eslint-preset.js --fix",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ specifiers:
   '@rollup/plugin-terser': ^0.1.0
   '@rollup/plugin-typescript': ^10.0.1
   '@rollup/pluginutils': ^5.0.2
+  '@types/node': ^18.14.2
   '@types/zen-observable': ^0.8.3
   '@typescript-eslint/eslint-plugin': ^5.45.0
   '@typescript-eslint/parser': ^5.45.0
@@ -29,9 +30,8 @@ specifiers:
   rollup: ^3.5.1
   rollup-plugin-cjs-check: ^1.0.1
   rollup-plugin-dts: ^5.1.1
-  tslib: ^2.4.1
   typescript: ^4.9.5
-  vitest: ^0.25.3
+  vitest: ^0.29.2
   zen-observable: ^0.10.0
 
 devDependencies:
@@ -41,8 +41,9 @@ devDependencies:
   '@rollup/plugin-commonjs': 23.0.3_rollup@3.5.1
   '@rollup/plugin-node-resolve': 15.0.1_rollup@3.5.1
   '@rollup/plugin-terser': 0.1.0_rollup@3.5.1
-  '@rollup/plugin-typescript': 10.0.1_i353se4wjqegof6rzgogenttmu
+  '@rollup/plugin-typescript': 10.0.1_7qkzlat3umsxdjhtme2mo4o6km
   '@rollup/pluginutils': 5.0.2_rollup@3.5.1
+  '@types/node': 18.14.2
   '@types/zen-observable': 0.8.3
   '@typescript-eslint/eslint-plugin': 5.45.0_kmw7swegqdzhqtxnpydwp4nxvm
   '@typescript-eslint/parser': 5.45.0_zbm6mgjew7sm4ssghrxdqoiad4
@@ -63,9 +64,8 @@ devDependencies:
   rollup: 3.5.1
   rollup-plugin-cjs-check: 1.0.1_rollup@3.5.1
   rollup-plugin-dts: 5.1.1_7qkzlat3umsxdjhtme2mo4o6km
-  tslib: 2.4.1
   typescript: 4.9.5
-  vitest: 0.25.3
+  vitest: 0.29.2
   zen-observable: 0.10.0
 
 packages:
@@ -500,7 +500,7 @@ packages:
       terser: 5.16.1
     dev: true
 
-  /@rollup/plugin-typescript/10.0.1_i353se4wjqegof6rzgogenttmu:
+  /@rollup/plugin-typescript/10.0.1_7qkzlat3umsxdjhtme2mo4o6km:
     resolution: {integrity: sha512-wBykxRLlX7EzL8BmUqMqk5zpx2onnmRMSw/l9M1sVfkJvdwfxogZQVNUM9gVMJbjRLDR5H6U0OMOrlDGmIV45A==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -516,7 +516,6 @@ packages:
       '@rollup/pluginutils': 5.0.2_rollup@3.5.1
       resolve: 1.22.1
       rollup: 3.5.1
-      tslib: 2.4.1
       typescript: 4.9.5
     dev: true
 
@@ -573,8 +572,8 @@ packages:
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
     dev: true
 
-  /@types/node/18.11.10:
-    resolution: {integrity: sha512-juG3RWMBOqcOuXC643OAdSA525V44cVgGV6dUDuiFtss+8Fk5x1hI93Rsld43VeJVIeqlP9I7Fn9/qaVqoEAuQ==}
+  /@types/node/18.14.2:
+    resolution: {integrity: sha512-1uEQxww3DaghA0RxqHx0O0ppVlo43pJhepY51OxuQIKHpjbnYLA7vcdwioNPzIqmC2u3I/dmylcqjlh0e7AyUA==}
     dev: true
 
   /@types/normalize-package-data/2.4.1:
@@ -730,6 +729,38 @@ packages:
       eslint-visitor-keys: 3.3.0
     dev: true
 
+  /@vitest/expect/0.29.2:
+    resolution: {integrity: sha512-wjrdHB2ANTch3XKRhjWZN0UueFocH0cQbi2tR5Jtq60Nb3YOSmakjdAvUa2JFBu/o8Vjhj5cYbcMXkZxn1NzmA==}
+    dependencies:
+      '@vitest/spy': 0.29.2
+      '@vitest/utils': 0.29.2
+      chai: 4.3.7
+    dev: true
+
+  /@vitest/runner/0.29.2:
+    resolution: {integrity: sha512-A1P65f5+6ru36AyHWORhuQBJrOOcmDuhzl5RsaMNFe2jEkoj0faEszQS4CtPU/LxUYVIazlUtZTY0OEZmyZBnA==}
+    dependencies:
+      '@vitest/utils': 0.29.2
+      p-limit: 4.0.0
+      pathe: 1.1.0
+    dev: true
+
+  /@vitest/spy/0.29.2:
+    resolution: {integrity: sha512-Hc44ft5kaAytlGL2PyFwdAsufjbdOvHklwjNy/gy/saRbg9Kfkxfh+PklLm1H2Ib/p586RkQeNFKYuJInUssyw==}
+    dependencies:
+      tinyspy: 1.0.2
+    dev: true
+
+  /@vitest/utils/0.29.2:
+    resolution: {integrity: sha512-F14/Uc+vCdclStS2KEoXJlOLAEyqRhnw0gM27iXw9bMTcyKRPJrQ+rlC6XZ125GIPvvKYMPpVxNhiou6PsEeYQ==}
+    dependencies:
+      cli-truncate: 3.1.0
+      diff: 5.1.0
+      loupe: 2.3.6
+      picocolors: 1.0.0
+      pretty-format: 27.5.1
+    dev: true
+
   /acorn-dynamic-import/4.0.0_acorn@6.4.2:
     resolution: {integrity: sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw==}
     deprecated: This is probably built in to whatever tool you're using. If you still need it... idk
@@ -768,6 +799,12 @@ packages:
 
   /acorn/8.8.1:
     resolution: {integrity: sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+    dev: true
+
+  /acorn/8.8.2:
+    resolution: {integrity: sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
     dev: true
@@ -823,6 +860,11 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       color-convert: 2.0.1
+    dev: true
+
+  /ansi-styles/5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
     dev: true
 
   /ansi-styles/6.2.1:
@@ -926,6 +968,11 @@ packages:
   /builtin-modules/3.3.0:
     resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
     engines: {node: '>=6'}
+    dev: true
+
+  /cac/6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
     dev: true
 
   /call-bind/1.0.2:
@@ -1249,6 +1296,11 @@ packages:
   /detect-indent/6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
+    dev: true
+
+  /diff/5.1.0:
+    resolution: {integrity: sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==}
+    engines: {node: '>=0.3.1'}
     dev: true
 
   /dir-glob/3.0.1:
@@ -2339,6 +2391,10 @@ packages:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
     dev: true
 
+  /jsonc-parser/3.2.0:
+    resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
+    dev: true
+
   /jsonfile/4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
     optionalDependencies:
@@ -2610,6 +2666,15 @@ packages:
     engines: {node: '>= 8.0.0'}
     dev: true
 
+  /mlly/1.1.1:
+    resolution: {integrity: sha512-Jnlh4W/aI4GySPo6+DyTN17Q75KKbLTyFK8BrGhjNP4rxuUjbRWhE6gHg3bs33URWAF44FRm7gdQA348i3XxRw==}
+    dependencies:
+      acorn: 8.8.2
+      pathe: 1.1.0
+      pkg-types: 1.0.2
+      ufo: 1.1.1
+    dev: true
+
   /ms/2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
     dev: true
@@ -2767,6 +2832,13 @@ packages:
       yocto-queue: 0.1.0
     dev: true
 
+  /p-limit/4.0.0:
+    resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      yocto-queue: 1.0.0
+    dev: true
+
   /p-locate/4.1.0:
     resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
     engines: {node: '>=8'}
@@ -2864,6 +2936,10 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /pathe/1.1.0:
+    resolution: {integrity: sha512-ODbEPR0KKHqECXW1GoxdDb+AZvULmXjVPy4rt+pGo2+TnjJTIPJQSVS6N63n8T2Ip+syHhbn52OewKicV0373w==}
+    dev: true
+
   /pathval/1.1.1:
     resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
     dev: true
@@ -2913,6 +2989,14 @@ packages:
       find-up: 5.0.0
     dev: true
 
+  /pkg-types/1.0.2:
+    resolution: {integrity: sha512-hM58GKXOcj8WTqUXnsQyJYXdeAPbythQgEF3nTcEo+nkD49chjQ9IKm/QJy9xf6JakXptz86h7ecP2024rrLaQ==}
+    dependencies:
+      jsonc-parser: 3.2.0
+      mlly: 1.1.1
+      pathe: 1.1.0
+    dev: true
+
   /please-upgrade-node/3.2.0:
     resolution: {integrity: sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==}
     dependencies:
@@ -2956,6 +3040,15 @@ packages:
     hasBin: true
     dev: true
 
+  /pretty-format/27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+    dev: true
+
   /pseudomap/1.0.2:
     resolution: {integrity: sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==}
     dev: true
@@ -2972,6 +3065,10 @@ packages:
   /quick-lru/4.0.1:
     resolution: {integrity: sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==}
     engines: {node: '>=8'}
+    dev: true
+
+  /react-is/17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
     dev: true
 
   /read-pkg-up/7.0.1:
@@ -3275,6 +3372,10 @@ packages:
       object-inspect: 1.12.2
     dev: true
 
+  /siginfo/2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+    dev: true
+
   /signal-exit/3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
     dev: true
@@ -3378,6 +3479,14 @@ packages:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
     dev: true
 
+  /stackback/0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+    dev: true
+
+  /std-env/3.3.2:
+    resolution: {integrity: sha512-uUZI65yrV2Qva5gqE0+A7uVAvO40iPo6jGhs7s8keRfHCmtg+uB2X6EiLGCI9IgL1J17xGhvoOqSz79lzICPTA==}
+    dev: true
+
   /stream-transform/2.1.3:
     resolution: {integrity: sha512-9GHUiM5hMiCi6Y03jD2ARC1ettBXkQBoQAe7nJsPknnI0ow10aXjTnew8QtYQmLjzn974BnmWEAJgCY6ZP1DeQ==}
     dependencies:
@@ -3468,10 +3577,10 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /strip-literal/0.4.2:
-    resolution: {integrity: sha512-pv48ybn4iE1O9RLgCAN0iU4Xv7RlBTiit6DKmMiErbs9x1wH6vXBs45tWc0H5wUIF6TLTrKweqkmYF/iraQKNw==}
+  /strip-literal/1.0.1:
+    resolution: {integrity: sha512-QZTsipNpa2Ppr6v1AmJHESqJ3Uz247MUS0OjrnnZjFAvEoWqxuyFuXn2xLgMtRnijJShAa1HL0gtJyUs7u7n3Q==}
     dependencies:
-      acorn: 8.8.1
+      acorn: 8.8.2
     dev: true
 
   /supports-color/5.5.0:
@@ -3521,8 +3630,8 @@ packages:
     resolution: {integrity: sha512-hGYWYBMPr7p4g5IarQE7XhlyWveh1EKhy4wUBS1LrHXCKYgvz+4/jCqgmJqZxxldesn05vccrtME2RLLZNW7iA==}
     dev: true
 
-  /tinypool/0.3.0:
-    resolution: {integrity: sha512-NX5KeqHOBZU6Bc0xj9Vr5Szbb1j8tUHIeD18s41aDJaPeC5QTdEhK0SpdpUrZlj2nv5cctNcSjaKNanXlfcVEQ==}
+  /tinypool/0.3.1:
+    resolution: {integrity: sha512-zLA1ZXlstbU2rlpA4CIeVaqvWq41MTWqLY3FfsAXgC8+f7Pk7zroaJQxDgxn1xNudKW6Kmj4808rPFShUlIRmQ==}
     engines: {node: '>=14.0.0'}
     dev: true
 
@@ -3639,6 +3748,10 @@ packages:
     hasBin: true
     dev: true
 
+  /ufo/1.1.1:
+    resolution: {integrity: sha512-MvlCc4GHrmZdAllBc0iUDowff36Q9Ndw/UzqmEKyrfSzokTd9ZCy1i+IIk5hrYKkjoYVQyNbrw7/F8XJ2rEwTg==}
+    dev: true
+
   /unbox-primitive/1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
     dependencies:
@@ -3689,7 +3802,28 @@ packages:
       spdx-expression-parse: 3.0.1
     dev: true
 
-  /vite/3.2.4_@types+node@18.11.10:
+  /vite-node/0.29.2_@types+node@18.14.2:
+    resolution: {integrity: sha512-5oe1z6wzI3gkvc4yOBbDBbgpiWiApvuN4P55E8OI131JGrSuo4X3SOZrNmZYo4R8Zkze/dhi572blX0zc+6SdA==}
+    engines: {node: '>=v14.16.0'}
+    hasBin: true
+    dependencies:
+      cac: 6.7.14
+      debug: 4.3.4
+      mlly: 1.1.1
+      pathe: 1.1.0
+      picocolors: 1.0.0
+      vite: 3.2.4_@types+node@18.14.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
+  /vite/3.2.4_@types+node@18.14.2:
     resolution: {integrity: sha512-Z2X6SRAffOUYTa+sLy3NQ7nlHFU100xwanq1WDwqaiFiCe+25zdxP1TfCS5ojPV2oDDcXudHIoPnI1Z/66B7Yw==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
@@ -3714,7 +3848,7 @@ packages:
       terser:
         optional: true
     dependencies:
-      '@types/node': 18.11.10
+      '@types/node': 18.14.2
       esbuild: 0.15.17
       postcss: 8.4.19
       resolve: 1.22.1
@@ -3723,8 +3857,8 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /vitest/0.25.3:
-    resolution: {integrity: sha512-/UzHfXIKsELZhL7OaM2xFlRF8HRZgAHtPctacvNK8H4vOcbJJAMEgbWNGSAK7Y9b1NBe5SeM7VTuz2RsTHFJJA==}
+  /vitest/0.29.2:
+    resolution: {integrity: sha512-ydK9IGbAvoY8wkg29DQ4ivcVviCaUi3ivuPKfZEVddMTenFHUfB8EEDXQV8+RasEk1ACFLgMUqAaDuQ/Nk+mQA==}
     engines: {node: '>=v14.16.0'}
     hasBin: true
     peerDependencies:
@@ -3747,18 +3881,28 @@ packages:
     dependencies:
       '@types/chai': 4.3.4
       '@types/chai-subset': 1.3.3
-      '@types/node': 18.11.10
+      '@types/node': 18.14.2
+      '@vitest/expect': 0.29.2
+      '@vitest/runner': 0.29.2
+      '@vitest/spy': 0.29.2
+      '@vitest/utils': 0.29.2
       acorn: 8.8.1
       acorn-walk: 8.2.0
+      cac: 6.7.14
       chai: 4.3.7
       debug: 4.3.4
       local-pkg: 0.4.2
+      pathe: 1.1.0
+      picocolors: 1.0.0
       source-map: 0.6.1
-      strip-literal: 0.4.2
+      std-env: 3.3.2
+      strip-literal: 1.0.1
       tinybench: 2.3.1
-      tinypool: 0.3.0
+      tinypool: 0.3.1
       tinyspy: 1.0.2
-      vite: 3.2.4_@types+node@18.11.10
+      vite: 3.2.4_@types+node@18.14.2
+      vite-node: 0.29.2_@types+node@18.14.2
+      why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less
       - sass
@@ -3825,6 +3969,15 @@ packages:
     hasBin: true
     dependencies:
       isexe: 2.0.0
+    dev: true
+
+  /why-is-node-running/2.2.2:
+    resolution: {integrity: sha512-6tSwToZxTOcotxHeA+qGCq1mVzKR3CwcJGmVcY+QE8SHy6TnpFnh8PAvPNHYr7EcuVeG0QSMxtYCuO1ta/G/oA==}
+    engines: {node: '>=8'}
+    hasBin: true
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
     dev: true
 
   /word-wrap/1.2.3:
@@ -3927,6 +4080,11 @@ packages:
   /yocto-queue/0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+    dev: true
+
+  /yocto-queue/1.0.0:
+    resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
+    engines: {node: '>=12.20'}
     dev: true
 
   /zen-observable/0.10.0:

--- a/scripts/eslint-preset.js
+++ b/scripts/eslint-preset.js
@@ -1,3 +1,4 @@
+const { prettier: prettierConfig } = require('../package.json');
 module.exports = {
   parserOptions: {
     ecmaVersion: 9,
@@ -14,13 +15,10 @@ module.exports = {
     'no-console': ['error', { allow: ['warn', 'error'] }],
     'prefer-arrow/prefer-arrow-functions': 'off',
     'prefer-rest-params': 'off',
-
     'prettier/prettier': [
       'error',
       {
-        singleQuote: true,
-        arrowParens: 'avoid',
-        trailingComma: 'es5',
+        ...prettierConfig,
       },
     ],
   },
@@ -29,6 +27,7 @@ module.exports = {
     {
       files: ['*.ts'],
       parser: '@typescript-eslint/parser',
+      plugins: ['@typescript-eslint'],
       extends: ['plugin:@typescript-eslint/recommended', 'prettier'],
       rules: {
         '@typescript-eslint/explicit-module-boundary-types': 'off',

--- a/scripts/rollup.config.mjs
+++ b/scripts/rollup.config.mjs
@@ -8,6 +8,8 @@ import dts from 'rollup-plugin-dts';
 
 import flowTypings from './flow-typings-plugin.mjs';
 
+const DEBUG_MODE = process.env.DEBUG === 'true';
+
 const commonPlugins = [
   resolve({
     extensions: ['.mjs', '.js', '.ts'],
@@ -25,7 +27,7 @@ const commonPlugins = [
   typescript({
     exclude: ['src/**/*.test.ts', '**/__tests__/*'],
     compilerOptions: {
-      sourceMap: true,
+      sourceMap: Boolean(DEBUG_MODE),
       sourceRoot: './',
       noEmit: false,
       declaration: false,
@@ -45,6 +47,7 @@ const jsPlugins = [
       dangerousForOf: true,
       dangerousTaggedTemplateString: true,
       destructuring: false,
+      // @ts-ignore
       asyncAwait: false,
       arrow: false,
       classes: false,
@@ -59,6 +62,7 @@ const jsPlugins = [
   }),
 
   terser({
+    // @ts-ignore
     warnings: true,
     ecma: 2015,
     keep_fnames: true,
@@ -88,11 +92,7 @@ const jsPlugins = [
   }),
 ];
 
-const dtsPlugins = [
-  ...commonPlugins,
-  dts(),
-  flowTypings(),
-];
+const dtsPlugins = [...commonPlugins, dts(), flowTypings()];
 
 const output = format => {
   const extension = format === 'esm' ? '.mjs' : '.js';
@@ -101,7 +101,7 @@ const output = format => {
     entryFileNames: '[name]' + extension,
     dir: './dist',
     exports: 'named',
-    sourcemap: true,
+    sourcemap: Boolean(DEBUG_MODE),
     indent: false,
     freeze: false,
     strict: false,
@@ -135,10 +135,7 @@ const commonConfig = {
 const jsConfig = {
   ...commonConfig,
   plugins: jsPlugins,
-  output: [
-    output('esm'),
-    output('cjs'),
-  ],
+  output: [output('esm'), output('cjs')],
 };
 
 const dtsConfig = {
@@ -157,11 +154,8 @@ const dtsConfig = {
   output: {
     dir: './dist',
     entryFileNames: '[name].d.ts',
-    format: 'es'
+    format: 'es',
   },
 };
 
-export default [
-  jsConfig,
-  dtsConfig,
-];
+export default [jsConfig, dtsConfig];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,20 +5,20 @@
     "noEmit": true,
     "esModuleInterop": true,
     "noUnusedLocals": true,
-    "rootDir": "./src",
     "baseUrl": ".",
-    "outDir": "dist/cjs",
-    "lib": ["dom", "esnext"],
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "jsx": "react",
     "declaration": false,
-    "module": "es2015",
+    "module": "ESNext",
     "moduleResolution": "node",
-    "target": "esnext",
+    "checkJs": true,
+    "target": "ESNext",
     "strict": true,
     "noImplicitAny": false,
     "noUnusedParameters": true,
     "skipLibCheck": true,
-    "isolatedModules": true
+    "isolatedModules": true,
+    "resolveJsonModule": true
   },
-  "include": ["src"]
+  "include": ["src", "scripts"]
 }


### PR DESCRIPTION
Thank you for this amazing library that I use quite frequently. I've made slight updates here and there mainly to config stuff.

Updates made:

- moved `"types"` inside `"exports"` to the top of `"."` entry as suggested in [tyoescriptlang.org](https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing),
- disabled generating `sourceMap`s unless environment variable `DEBUG` is set to `true` since source maps are for dev/debugging purposes only,
- removed `src` from `dist`,
- in `devDependencies`: added `@types/node`, updated `vitest`, and removed `tslib`,
- in `ci.yml` updated `branches: main` to array format cause it was showing an error and github syntax says it should be array,
- `prettier`/`eslint`: consolidated `prettier` rules to one place in `package.json` and `require`d the object in `eslint` + enabled `cache` for eslint,
- enabled type checking in `./scripts` and added explicit `@ts-ignore` for fields that are not part of the imported packages,
- updated `tsconfig.json`.


Cheers