### PR TITLE
fix: Add missing filter overload to allow for type narrowing

### DIFF
--- a/.changeset/khaki-lemons-argue.md
+++ b/.changeset/khaki-lemons-argue.md
@@ -1,0 +1,5 @@
+---
+'wonka': patch
+---
+
+Add missing overload definition for `filter`, which allows types to be narrowed, e.g. by specifying a type predicate return type.

--- a/src/__tests__/operators.test.ts
+++ b/src/__tests__/operators.test.ts
@@ -231,10 +231,12 @@ describe('filter', () => {
   passesAsyncSequence(noop);
 
   it('prevents emissions for which a predicate fails', () => {
-    const { source, next } = sources.makeSubject();
+    const { source, next } = sources.makeSubject<boolean>();
     const fn = vi.fn();
 
-    sinks.forEach(fn)(operators.filter(x => !!x)(source));
+    sinks.forEach((x: true) => {
+      fn(x);
+    })(operators.filter((x): x is true => !!x)(source));
 
     next(false);
     expect(fn).not.toHaveBeenCalled();

--- a/src/operators.ts
+++ b/src/operators.ts
@@ -1,4 +1,4 @@
-import { Source, Sink, Operator, SignalKind, TalkbackKind, TalkbackFn } from './types';
+import { Push, Source, Sink, Operator, SignalKind, TalkbackKind, TalkbackFn } from './types';
 import { push, start, talkbackPlaceholder } from './helpers';
 import { fromArray } from './sources';
 
@@ -268,7 +268,9 @@ export function concat<T>(sources: Source<T>[]): Source<T> {
  * );
  * ```
  */
-export function filter<T>(predicate: (value: T) => boolean): Operator<T, T> {
+function filter<In, Out extends In>(predicate: (value: In) => value is Out): Operator<In, Out>;
+function filter<T>(predicate: (value: T) => boolean): Operator<T, T>;
+function filter<In, Out>(predicate: (value: In) => boolean): Operator<In, Out> {
   return source => sink => {
     let talkback = talkbackPlaceholder;
     source(signal => {
@@ -280,11 +282,13 @@ export function filter<T>(predicate: (value: T) => boolean): Operator<T, T> {
       } else if (!predicate(signal[0])) {
         talkback(TalkbackKind.Pull);
       } else {
-        sink(signal);
+        sink(signal as Push<any>);
       }
     });
   };
 }
+
+export { filter };
 
 /** Maps emitted values using the passed mapping function.
  *


### PR DESCRIPTION
Resolves #148 

This adds a missing overload for `filter` which will allow us to narrow types, e.g. by applying type conditions. We can now specify narrowing types and still get the desired output without casting:

```ts
pipe(
  fromArray([false, true, false, true]),
  filter((x): x is true => !!x),
  forEach(console.log), // always true
);