### PR TITLE
fix: subscription closed does not comply with proposal

### DIFF
--- a/.changeset/five-rules-bow.md
+++ b/.changeset/five-rules-bow.md
@@ -1,0 +1,5 @@
+---
+'wonka': patch
+---
+
+Make `closed: boolean` on `ObservableSubscription`s a required field to comply with the Observable proposal's type spec.

--- a/src/observable.ts
+++ b/src/observable.ts
@@ -76,7 +76,7 @@ interface ObservableLike<T> {
    * @see {@link ObservableObserver} for the callbacks in an object that are called as Observables
    * issue events.
    */
-  subscribe(observer: ObservableObserver<T>): ObservableSubscription;
+  subscribe(observer: ObservableObserver<T>): { unsubscribe(): void };
 
   /** The well-known symbol specifying the default ES Observable for an object. */
   [Symbol.observable]?(): Observable<T>;

--- a/src/observable.ts
+++ b/src/observable.ts
@@ -26,7 +26,7 @@ interface ObservableSubscription {
    *
    * @readonly
    */
-  closed?: boolean;
+  closed: boolean;
   /** Cancels the subscription.
    * @remarks
    * This cancels the ongoing subscription and the {@link ObservableObserver}'s callbacks will


### PR DESCRIPTION
Thank you for creating a great lightweight library.

I have fixed the difference between [proposal-observable](https://github.com/tc39/proposal-observable#observable) and the closed type in subscription.

The following are subscription types for proposal-observable.
```typescript
interface Subscription {

    // Cancels the subscription
    unsubscribe() : void;

    // A boolean value indicating whether the subscription is closed
    get closed() : Boolean;
}
```
Current wonka subscription type.
```typescript
interface ObservableSubscription {
  /** A boolean flag indicating whether the subscription is closed.
   * @remarks
   * When `true`, the subscription will not issue new values to the {@link ObservableObserver} and
   * has terminated. No new values are expected.
   *
   * @readonly
   */
  closed?: boolean;
  /** Cancels the subscription.
   * @remarks
   * This cancels the ongoing subscription and the {@link ObservableObserver}'s callbacks will
   * subsequently not be called at all. The subscription will be terminated and become inactive.
   */
  unsubscribe(): void;
}
```

## Confirmed
- pnpm build passes
- pnpm check passes
- pnpm lint passes
- pnpn test passes