### PR TITLE
chore: Update data structure

### DIFF
--- a/.changeset/orange-melons-tease.md
+++ b/.changeset/orange-melons-tease.md
@@ -1,0 +1,5 @@
+---
+'wonka': patch
+---
+
+Convert `Push<T>` and `Start<T>` signals to `{ tag, 0: value }` objects, which are sufficiently backwards compatible and result in slightly faster execution in v8.

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -24,16 +24,18 @@ export const talkbackPlaceholder: TalkbackFn = teardownPlaceholder;
  * @internal
  */
 export function start<T>(talkback: TalkbackFn): Start<T> {
-  const box: any = [talkback];
-  box.tag = SignalKind.Start;
-  return box;
+  return {
+    tag: SignalKind.Start,
+    0: talkback,
+  } as Start<T>;
 }
 
 /** Wraps the passed value in a {@link Push | Push signal}.
  * @internal
  */
 export function push<T>(value: T): Push<T> {
-  const box: any = [value];
-  box.tag = SignalKind.Push;
-  return box;
+  return {
+    tag: SignalKind.Push,
+    0: value,
+  } as Push<T>;
 }


### PR DESCRIPTION
## Summary

This updates the internal data structures of `SignalKind` signals to be backwards compatible but simpler. This results in a slight speedup in V8.

```ts
// before
export function start<T>(talkback: TalkbackFn): Start<T> {
  const box: any = [talkback];
  box.tag = SignalKind.Start;
  return box;
}

export function push<T>(value: T): Push<T> {
  const box: any = [value];
  box.tag = SignalKind.Push;
  return box;
}

// after
export function start<T>(talkback: TalkbackFn): Start<T> {
  return {
    tag: SignalKind.Start,
    0: talkback,
  } as Start<T>;
}

export function push<T>(value: T): Push<T> {
  return {
    tag: SignalKind.Push,
    0: value,
  } as Push<T>;
}
```

These are backwards-compatible because Wonka code (even before the current major, is only ever guaranteed to access `[0]` or `.tag` but never any array primitives.

## Set of changes

- Replace `start()` and `push()` primitives
