### PR TITLE
feat: Add an addOne argument to takeWhile

### DIFF
--- a/.changeset/rich-pans-smoke.md
+++ b/.changeset/rich-pans-smoke.md
@@ -1,0 +1,5 @@
+---
+'wonka': minor
+---
+
+Add `addOne` argument to `takeWhile`, allowing an additional value to be issued.

--- a/src/__tests__/operators.test.ts
+++ b/src/__tests__/operators.test.ts
@@ -772,8 +772,26 @@ describe('takeWhile', () => {
     operators.takeWhile((x: any) => x < 2)(source)(fn);
     next(1);
     next(2);
+    next(3);
 
     expect(fn.mock.calls).toEqual([[start(expect.any(Function))], [push(1)], [SignalKind.End]]);
+  });
+
+  it('emits values while a predicate passes for all values plus an additional one', () => {
+    const { source, next } = sources.makeSubject<number>();
+    const fn = vi.fn();
+
+    operators.takeWhile((x: any) => x < 2, true)(source)(fn);
+    next(1);
+    next(2);
+    next(3);
+
+    expect(fn.mock.calls).toEqual([
+      [start(expect.any(Function))],
+      [push(1)],
+      [push(2)],
+      [SignalKind.End],
+    ]);
   });
 });
 

--- a/src/operators.ts
+++ b/src/operators.ts
@@ -1254,12 +1254,16 @@ export function takeUntil<S, T>(notifier: Source<S>): Operator<T, T> {
 /** Takes values from an input Source until a predicate function returns `false`.
  *
  * @param predicate - A function returning a boolean per value.
+ * @param addOne - Lets an additional input value pass on.
  * @returns An {@link Operator}.
  *
  * @remarks
  * `takeWhile` will issue all values as normal from the input {@link Source} until the `predicate`
  * function returns `false`. When the `predicate` function returns `false`, the current value is
  * omitted and the {@link Source} is closed.
+ *
+ * If `addOne` is set to `true`, the value for which the `predicate` first returned `false` is
+ * issued and passed on as well instead of being omitted.
  *
  * @example
  * ```ts
@@ -1272,7 +1276,7 @@ export function takeUntil<S, T>(notifier: Source<S>): Operator<T, T> {
  * );
  * ```
  */
-export function takeWhile<T>(predicate: (value: T) => boolean): Operator<T, T> {
+export function takeWhile<T>(predicate: (value: T) => boolean, addOne?: boolean): Operator<T, T> {
   return source => sink => {
     let talkback = talkbackPlaceholder;
     let ended = false;
@@ -1287,6 +1291,7 @@ export function takeWhile<T>(predicate: (value: T) => boolean): Operator<T, T> {
         sink(signal);
       } else if (!predicate(signal[0])) {
         ended = true;
+        if (addOne) sink(signal);
         sink(SignalKind.End);
         talkback(TalkbackKind.Close);
       } else {


### PR DESCRIPTION
## Summary

I realised this is impossible to express without a `takeUntil` and `share` operator, but is sometimes pretty handy, e.g. to say "take values until predicate returns false, but include the ending value".

This adds an `addOne?: boolean` argument to `takeWhile` which allows the first value that fails the predicate to also be issued on the output `Source` rather than being omitted.

This comes in handy for GraphQL’s incremental results, e.g. to express `takeWhile(result => !!result.hasNext)`. This is important, since the first result in GraphQL may pass `!hasNext` but will still contain new `data`. It's also, while implied in the spec, not guaranteed that the last `result` with `hasNext: false` won't carry a new result.

## Set of changes

- Add an `addOne` argument to `takeWhile`
