### PR TITLE
fix: Fix missing declare keyword on ambient enums

### DIFF
--- a/.changeset/light-cougars-enjoy.md
+++ b/.changeset/light-cougars-enjoy.md
@@ -1,0 +1,5 @@
+---
+'wonka': patch
+---
+
+Fix missing `declare` keyword on internal ambient enums.

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -6,7 +6,7 @@
  * the {@link Start} signal, to tell a {@link Source} to either send a new value (pulling) or stop
  * sending values altogether (cancellation).
  */
-export enum TalkbackKind {
+export declare enum TalkbackKind {
   /** Instructs the {@link Source} to send the next value. */
   Pull = 0,
   /** Instructs the {@link Source} to stop sending values and cancels it. */
@@ -41,7 +41,7 @@ export type TeardownFn = () => void;
  * @see {@link Start} for the data structure of the start signal.
  * @see {@link Push} for the data structure of the push signal, carrying values.
  */
-export enum SignalKind {
+export declare enum SignalKind {
   /**
    * Informs the {@link Sink} that it's being called by a {@link Source}.
    *


### PR DESCRIPTION
Resolves #158

- Fix missing `declare` keyword on ambient enums in `types.d.ts`