### PR TITLE
fix(docs): return value of `subscribe` is an object

### DIFF
--- a/docs/api/sinks.md
+++ b/docs/api/sinks.md
@@ -25,7 +25,7 @@ new incoming values.
 ```typescript
 import { pipe, subscribe } from 'wonka';
 
-const [unsubscribe] = pipe(
+const { unsubscribe } = pipe(
   source,
   subscribe((x) => console.log(x));
 );


### PR DESCRIPTION
fixes #163 