### PR TITLE
fix: Add missing Symbol.observable typings to build output

### DIFF
--- a/.changeset/fresh-tips-yell.md
+++ b/.changeset/fresh-tips-yell.md
@@ -1,0 +1,5 @@
+---
+'wonka': patch
+---
+
+Add missing `Symbol.observable` global declaration back to typings.

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,11 +1,5 @@
 import { TalkbackFn, TeardownFn, Start, Push, SignalKind } from './types';
 
-declare global {
-  interface SymbolConstructor {
-    readonly observable: symbol;
-  }
-}
-
 /** Placeholder {@link TeardownFn | teardown functions} that's a no-op.
  * @see {@link TeardownFn} for the definition and usage of teardowns.
  * @internal

--- a/src/observable.ts
+++ b/src/observable.ts
@@ -1,6 +1,14 @@
 import { Source, SignalKind, TalkbackKind } from './types';
 import { push, start, talkbackPlaceholder, observableSymbol } from './helpers';
 
+// NOTE: This must be placed in an exported file for `rollup-plugin-dts`
+// to include it in output typings files
+declare global {
+  interface SymbolConstructor {
+    readonly observable: symbol;
+  }
+}
+
 /** A definition of the ES Observable Subscription type that is returned by
  * {@link Observable.subscribe}
  *


### PR DESCRIPTION
Resolves #167

## Summary

This moves back the global `Symbol.observable` declaration to ensure that `rollup-plugin-dts` outputs it in the built typings. This also adds a note to ensure it stays intact.

## Set of changes

- Move `Symbol.observable` declaration back to exported `observable.ts`
