### PR TITLE
perf: remove extra `Promise` wrapper for `value` in `fromPromise` and `toPromise`

### DIFF
--- a/.changeset/three-dogs-crash.md
+++ b/.changeset/three-dogs-crash.md
@@ -1,0 +1,5 @@
+---
+'wonka': patch
+---
+
+Remove extra `Promise` wrapper for `value` in `fromPromise` and `toPromise`

--- a/src/sinks.ts
+++ b/src/sinks.ts
@@ -241,7 +241,7 @@ export function toPromise<T>(source: Source<T>): Promise<T> {
     let value: T | void;
     source(signal => {
       if (signal === SignalKind.End) {
-        Promise.resolve(value!).then(resolve);
+        resolve(value!);
       } else if (signal.tag === SignalKind.Start) {
         (talkback = signal[0])(TalkbackKind.Pull);
       } else {

--- a/src/sources.ts
+++ b/src/sources.ts
@@ -397,10 +397,8 @@ export function fromDomEvent(element: HTMLElement, event: string): Source<Event>
 export function fromPromise<T>(promise: Promise<T>): Source<T> {
   return make(observer => {
     promise.then(value => {
-      Promise.resolve(value).then(() => {
-        observer.next(value);
-        observer.complete();
-      });
+      observer.next(value);
+      observer.complete();
     });
     return teardownPlaceholder;
   });


### PR DESCRIPTION
## Summary

Removes unnecessary `Promise` wrappers. Since `Promise` can unroll itself, these operations only create overhead

For example:
```js
Promise.resolve()
  .then(() => Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(1)))))
  .then((value) => {
    console.log('val', value)
  });

// val 1
```
And
```js
new Promise(resolve => resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(1))))))
  .then((value) => console.log('val', value));

// val 1
```

## Set of changes

Removing unnecessary `Promise` wrappers in `sources.ts` and `sinks.ts`.