### PR TITLE
use asyncIteratorSymbol helper to check for async Iterator

### DIFF
--- a/src/sources.ts
+++ b/src/sources.ts
@@ -118,7 +118,7 @@ export function fromAsyncIterable<T>(iterable: AsyncIterable<T> | AsyncIterator<
  * for the JS Iterable protocol.
  */
 export function fromIterable<T>(iterable: Iterable<T> | AsyncIterable<T>): Source<T> {
-  if (iterable[Symbol.asyncIterator]) return fromAsyncIterable(iterable as AsyncIterable<T>);
+  if (iterable[asyncIteratorSymbol()]) return fromAsyncIterable(iterable as AsyncIterable<T>);
   return sink => {
     const iterator = iterable[Symbol.iterator]();
     let ended = false;


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR, but please make sure to open an issue or discuss
  your changes first, if you’re looking to submit a larger PR.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

This fix eliminates the possibility of a runtime error in environments without native support for `Symbol.asyncIterator` and async generators.  In these environments it's likely Symbol.asyncIterator is not defined.

Babel regenerator that transforms the source to support async generators falls back to "@@asyncIterator" when Symbol.asyncIterator is not available. 
https://github.com/facebook/regenerator/blob/main/packages/runtime/runtime.js#L17

The fix is to use the existing "asyncIteratorSymbol" helper in Wonka to return the symbol for asynIterator, which accounts for filled-in support.


## Set of changes

<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->
